### PR TITLE
Add 2025 outbreak dataset

### DIFF
--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -14,14 +14,14 @@ There are currently two separate workflows:
 
 ### Outbreak-specific
 
-This workflow produces a single analysis of the West Africa outbreak.
+This workflow produces analyses of specific ebola outbreaks. Configure which outbreaks in [outbreak-specific/config.yaml](./outbreak-specific/config.yaml).
 
 The workflow can be run from the top level pathogen repo directory:
 ```
 nextstrain build phylogenetic --snakefile outbreak-specific/Snakefile
 ```
 
-The resulting dataset can be viewed in a web browser:
+The resulting datasets can be viewed in a web browser:
 ```
 nextstrain view phylogenetic/outbreak-specific
 ```

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -26,6 +26,19 @@ The resulting datasets can be viewed in a web browser:
 nextstrain view phylogenetic/outbreak-specific
 ```
 
+There are currently two datasets configured, and each is a work in progress.
+
+#### Ebov-2013 / West-Africa 2014
+
+* The temporal analysis is wrong (root pushed back), which I think is due to the inclusion of relapse cases. We could try specifying a rate or explore ways to infer the rate based on a subset of samples within treetime. 
+* Missing colors & lat-longs. Some of this is misspelt geographical metadata to be fixed in ingest.
+* Alignment (mafft) takes a long time cf. nextclade alignment. We should compare the two approaches.
+
+#### Ebov-2025
+
+* Currently (2025-09-29) there are 4 available genomes. At this time [this virological post](https://virological.org/t/the-16th-ebola-virus-disease-outbreak-in-bulape-health-zone-kasai-democratic-republic-of-the-congo-a-new-spillover-event-from-an-unknown-reservoir-host/1003) is a better summary of the genomic situation.
+
+
 ### All-outbreaks
 
 This workflow subsamples genomes across outbreaks to present an overview of the known genomic history

--- a/phylogenetic/outbreak-specific/Snakefile
+++ b/phylogenetic/outbreak-specific/Snakefile
@@ -50,6 +50,8 @@ rule all:
 # If there are build specific customizations, they should be added with the
 # custom_rules imported below to ensure that the core workflow is not complicated
 # by build specific rules.
+include: "../../shared/vendored/snakemake/config.smk"
+include: "../../shared/vendored/snakemake/remote_files.smk"
 include: "../rules/prepare_sequences.smk"
 include: "../rules/construct_phylogeny.smk"
 include: "../rules/annotate_phylogeny.smk"

--- a/phylogenetic/outbreak-specific/Snakefile
+++ b/phylogenetic/outbreak-specific/Snakefile
@@ -2,8 +2,6 @@
 This is the main phylogenetic Snakefile that orchestrates the full phylogenetic
 workflow and defines its default output(s).
 """
-# The workflow filepaths are written relative to this Snakefile's base directory
-workdir: workflow.current_basedir
 
 # Use default configuration values. Override with Snakemake's --configfile/--config options.
 configfile: "config.yaml"

--- a/phylogenetic/outbreak-specific/Snakefile
+++ b/phylogenetic/outbreak-specific/Snakefile
@@ -3,6 +3,8 @@ This is the main phylogenetic Snakefile that orchestrates the full phylogenetic
 workflow and defines its default output(s).
 """
 
+PHYLO_DIR = os.path.normpath(os.path.join(workflow.basedir, ".."))
+
 # Immediately include the `config.smk` ruleset to set the `config` structure as soon as possible
 include: "../rules/config.smk"
 
@@ -50,7 +52,6 @@ rule all:
 # If there are build specific customizations, they should be added with the
 # custom_rules imported below to ensure that the core workflow is not complicated
 # by build specific rules.
-include: "../../shared/vendored/snakemake/config.smk"
 include: "../../shared/vendored/snakemake/remote_files.smk"
 include: "../rules/prepare_sequences.smk"
 include: "../rules/construct_phylogeny.smk"

--- a/phylogenetic/outbreak-specific/Snakefile
+++ b/phylogenetic/outbreak-specific/Snakefile
@@ -3,8 +3,8 @@ This is the main phylogenetic Snakefile that orchestrates the full phylogenetic
 workflow and defines its default output(s).
 """
 
-# Use default configuration values. Override with Snakemake's --configfile/--config options.
-configfile: "config.yaml"
+# Immediately include the `config.smk` ruleset to set the `config` structure as soon as possible
+include: "../rules/config.smk"
 
 # Validate 'builds'
 from textwrap import dedent
@@ -50,7 +50,6 @@ rule all:
 # If there are build specific customizations, they should be added with the
 # custom_rules imported below to ensure that the core workflow is not complicated
 # by build specific rules.
-include: "../rules/config.smk"
 include: "../rules/prepare_sequences.smk"
 include: "../rules/construct_phylogeny.smk"
 include: "../rules/annotate_phylogeny.smk"

--- a/phylogenetic/outbreak-specific/config.yaml
+++ b/phylogenetic/outbreak-specific/config.yaml
@@ -7,9 +7,36 @@
 id_column: "accession"
 
 builds:
-  - west-africa-2014
+  - drc-2025
+  # - west-africa-2014
 
 build_params:
+  drc-2025:
+    ancestral:
+      inference: joint
+
+    files:
+      reference: drc-2025/NC_002549.1.gb  # FIXME: use another reference?
+      lat_longs: ../defaults/lat_longs.tsv
+      auspice_config: drc-2025/auspice_config.json
+      description: drc-2025/description.md
+
+    filter:
+      min_length: 18000
+      exclude: ../defaults/exclude.txt
+      include: drc-2025/include.txt
+      min_date: "2025-08-01"
+
+    refine:
+      timetree: false
+      coalescent: skyline
+      date_inference: marginal
+
+    traits:
+      columns:
+        - country
+        - division
+
   west-africa-2014:
     ancestral:
       inference: joint

--- a/phylogenetic/outbreak-specific/config.yaml
+++ b/phylogenetic/outbreak-specific/config.yaml
@@ -24,11 +24,9 @@ build_params:
       reference: outbreak-specific/drc-2025/NC_002549.1.gb # Yambuku_Mayinga_Reference
 
     filter:
-      min_length: 18000
-      exclude: defaults/exclude.txt
+      min_length: 10000
+      query: outbreak=="Ebov-2025"
       include: outbreak-specific/drc-2025/include.txt
-      min_date: "2025-08-01"
-      exclude_ambiguous_dates_by: month
 
     refine:
       timetree: false
@@ -58,11 +56,9 @@ build_params:
     filter:
       min_length: 18000
       exclude_where: is_lab_host=true
-      exclude: defaults/exclude.txt
-      include: outbreak-specific/west-africa-2014/include.txt
+      query: (outbreak=="Ebov-2013" | outbreak=="Ebov-2013/r2021")
       subsample_max_sequences: 30
-      min_date: 2012
-      max_date: 2017
+      include: outbreak-specific/west-africa-2014/include.txt
       group_by:
         - division
         - year

--- a/phylogenetic/outbreak-specific/config.yaml
+++ b/phylogenetic/outbreak-specific/config.yaml
@@ -21,15 +21,15 @@ build_params:
       inference: joint
 
     files:
-      reference: drc-2025/NC_002549.1.gb  # FIXME: use another reference?
-      lat_longs: ../defaults/lat_longs.tsv
-      auspice_config: drc-2025/auspice_config.json
-      description: drc-2025/description.md
+      reference: outbreak-specific/drc-2025/NC_002549.1.gb  # FIXME: use another reference?
+      lat_longs: defaults/lat_longs.tsv
+      auspice_config: outbreak-specific/drc-2025/auspice_config.json
+      description: outbreak-specific/drc-2025/description.md
 
     filter:
       min_length: 18000
-      exclude: ../defaults/exclude.txt
-      include: drc-2025/include.txt
+      exclude: defaults/exclude.txt
+      include: outbreak-specific/drc-2025/include.txt
       min_date: "2025-08-01"
       exclude_ambiguous_dates_by: month
 
@@ -52,16 +52,16 @@ build_params:
       inference: joint
 
     files:
-      reference: west-africa-2014/ebola_outgroup.gb
-      lat_longs: ../defaults/lat_longs.tsv
-      auspice_config: west-africa-2014/auspice_config.json
-      description: west-africa-2014/description.md
+      reference: outbreak-specific/west-africa-2014/ebola_outgroup.gb
+      lat_longs: defaults/lat_longs.tsv
+      auspice_config: outbreak-specific/west-africa-2014/auspice_config.json
+      description: outbreak-specific/west-africa-2014/description.md
 
     filter:
       min_length: 18000
       exclude_where: is_lab_host=true
-      exclude: ../defaults/exclude.txt
-      include: west-africa-2014/include.txt
+      exclude: defaults/exclude.txt
+      include: outbreak-specific/west-africa-2014/include.txt
       subsample_max_sequences: 30
       min_date: 2012
       max_date: 2017
@@ -81,4 +81,4 @@ build_params:
         - division
 
     export:
-      warning: west-africa-2014/description.md
+      warning: outbreak-specific/west-africa-2014/description.md

--- a/phylogenetic/outbreak-specific/config.yaml
+++ b/phylogenetic/outbreak-specific/config.yaml
@@ -13,18 +13,15 @@ inputs:
 
 builds:
   - drc-2025
-  # - west-africa-2014
+  - west-africa-2014
 
 build_params:
   drc-2025:
     ancestral:
       inference: joint
 
-    files:
-      reference: outbreak-specific/drc-2025/NC_002549.1.gb  # FIXME: use another reference?
-      lat_longs: defaults/lat_longs.tsv
-      auspice_config: outbreak-specific/drc-2025/auspice_config.json
-      description: outbreak-specific/drc-2025/description.md
+    align:
+      reference: outbreak-specific/drc-2025/NC_002549.1.gb # Yambuku_Mayinga_Reference
 
     filter:
       min_length: 18000
@@ -38,6 +35,7 @@ build_params:
       coalescent: skyline
       date_inference: marginal
 
+
     traits:
       columns:
         - country
@@ -46,16 +44,16 @@ build_params:
     export:
       warning: >-
         Work in progress.
+      lat_longs: defaults/lat_longs.tsv
+      auspice_config: outbreak-specific/drc-2025/auspice_config.json
+      description: outbreak-specific/drc-2025/description.md
 
   west-africa-2014:
     ancestral:
       inference: joint
 
-    files:
-      reference: outbreak-specific/west-africa-2014/ebola_outgroup.gb
-      lat_longs: defaults/lat_longs.tsv
-      auspice_config: outbreak-specific/west-africa-2014/auspice_config.json
-      description: outbreak-specific/west-africa-2014/description.md
+    align:
+      reference: outbreak-specific/west-africa-2014/ebola_outgroup.gb # Makona_Liberia_Reference
 
     filter:
       min_length: 18000
@@ -82,3 +80,6 @@ build_params:
 
     export:
       warning: outbreak-specific/west-africa-2014/description.md
+      lat_longs: defaults/lat_longs.tsv
+      auspice_config: outbreak-specific/west-africa-2014/auspice_config.json
+      description: outbreak-specific/west-africa-2014/description.md

--- a/phylogenetic/outbreak-specific/config.yaml
+++ b/phylogenetic/outbreak-specific/config.yaml
@@ -79,3 +79,4 @@ build_params:
       lat_longs: defaults/lat_longs.tsv
       auspice_config: outbreak-specific/west-africa-2014/auspice_config.json
       description: outbreak-specific/west-africa-2014/description.md
+      colors: outbreak-specific/west-africa-2014/colors.txt

--- a/phylogenetic/outbreak-specific/config.yaml
+++ b/phylogenetic/outbreak-specific/config.yaml
@@ -38,6 +38,10 @@ build_params:
         - country
         - division
 
+    export:
+      warning: >-
+        Work in progress.
+
   west-africa-2014:
     ancestral:
       inference: joint

--- a/phylogenetic/outbreak-specific/config.yaml
+++ b/phylogenetic/outbreak-specific/config.yaml
@@ -26,6 +26,7 @@ build_params:
       exclude: ../defaults/exclude.txt
       include: drc-2025/include.txt
       min_date: "2025-08-01"
+      exclude_ambiguous_dates_by: month
 
     refine:
       timetree: false

--- a/phylogenetic/outbreak-specific/config.yaml
+++ b/phylogenetic/outbreak-specific/config.yaml
@@ -30,8 +30,8 @@ build_params:
 
     refine:
       timetree: false
-      coalescent: skyline
-      date_inference: marginal
+      root: PP_000PHH3 # Yambuku_Mayinga_Reference, force-included in include.txt
+      remove_outgroup: true
 
 
     traits:
@@ -66,6 +66,7 @@ build_params:
 
     refine:
       timetree: true
+      confidence: true
       coalescent: skyline
       date_inference: marginal
 

--- a/phylogenetic/outbreak-specific/config.yaml
+++ b/phylogenetic/outbreak-specific/config.yaml
@@ -6,6 +6,11 @@
 
 id_column: "accession"
 
+inputs:
+  - name: local_ingest
+    metadata: ../ingest/results/metadata.tsv
+    sequences: ../ingest/results/sequences.fasta
+
 builds:
   - drc-2025
   # - west-africa-2014

--- a/phylogenetic/outbreak-specific/drc-2025/NC_002549.1.gb
+++ b/phylogenetic/outbreak-specific/drc-2025/NC_002549.1.gb
@@ -1,0 +1,772 @@
+LOCUS       NC_002549              18959 bp    cRNA    linear   VRL 13-AUG-2018
+DEFINITION  Zaire ebolavirus isolate Ebola
+            virus/H.sapiens-tc/COD/1976/Yambuku-Mayinga, complete genome.
+ACCESSION   NC_002549
+VERSION     NC_002549.1
+DBLINK      BioProject: PRJNA485481
+KEYWORDS    RefSeq.
+SOURCE      Zaire ebolavirus
+  ORGANISM  Zaire ebolavirus
+            Viruses; Riboviria; Orthornavirae; Negarnaviricota;
+            Haploviricotina; Monjiviricetes; Mononegavirales; Filoviridae;
+            Orthoebolavirus; Orthoebolavirus zairense.
+REFERENCE   1  (bases 1 to 18959)
+  AUTHORS   Volchkov,V.E., Volchkova,V.A., Chepurnov,A.A., Blinov,V.M.,
+            Dolnik,O., Netesov,S.V. and Feldmann,H.
+  TITLE     Characterization of the L gene and 5' trailer region of Ebola virus
+  JOURNAL   J. Gen. Virol. 80 (Pt 2), 355-362 (1999)
+   PUBMED   10073695
+REFERENCE   2  (bases 1 to 18959)
+  AUTHORS   Volchkov,V.E., Volchkova,V.A., Slenczka,W., Klenk,H.D. and
+            Feldmann,H.
+  TITLE     Release of viral glycoproteins during Ebola virus infection
+  JOURNAL   Virology 245 (1), 110-119 (1998)
+   PUBMED   9614872
+REFERENCE   3  (bases 1 to 18959)
+  AUTHORS   Volchkov,V.E., Feldmann,H., Volchkova,V.A. and Klenk,H.D.
+  TITLE     Processing of the Ebola virus glycoprotein by the proprotein
+            convertase furin
+  JOURNAL   Proc. Natl. Acad. Sci. U.S.A. 95 (10), 5762-5767 (1998)
+   PUBMED   9576958
+REFERENCE   4  (bases 1 to 18959)
+  AUTHORS   Volchkov,V.E., Becker,S., Volchkova,V.A., Ternovoj,V.A.,
+            Kotov,A.N., Netesov,S.V. and Klenk,H.D.
+  TITLE     GP mRNA of Ebola virus is edited by the Ebola virus polymerase and
+            by T7 and vaccinia virus polymerases
+  JOURNAL   Virology 214 (2), 421-430 (1995)
+   PUBMED   8553543
+REFERENCE   5  (bases 1 to 18959)
+  AUTHORS   Bukreyev,A.A., Volchkov,V.E., Blinov,V.M. and Netesov,S.V.
+  TITLE     The VP35 and VP40 proteins of filoviruses. Homology between Marburg
+            and Ebola viruses
+  JOURNAL   FEBS Lett. 322 (1), 41-46 (1993)
+   PUBMED   8482365
+REFERENCE   6  (bases 1 to 18959)
+  CONSRTM   NCBI Genome Project
+  TITLE     Direct Submission
+  JOURNAL   Submitted (27-SEP-2000) National Center for Biotechnology
+            Information, NIH, Bethesda, MD 20894, USA
+REFERENCE   7  (bases 1 to 18959)
+  AUTHORS   Volchkov,V.E.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (02-JUN-2000) Institute of Virology, Philipps-University
+            Marburg, Robert-Koch-Str. 17, Marburg 35037, Germany
+  REMARK    Sequence update by submitter
+REFERENCE   8  (bases 1 to 18959)
+  AUTHORS   Volchkov,V.E.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (20-AUG-1998) Institute of Virology, Philipps-University
+            Marburg, Robert-Koch-Str. 17, Marburg 35037, Germany
+COMMENT     REVIEWED REFSEQ: This record has been curated by NCBI staff. The
+            reference sequence is identical to AF086833.
+            COMPLETENESS: full length.
+FEATURES             Location/Qualifiers
+     source          1..18959
+                     /organism="Zaire ebolavirus"
+                     /mol_type="viral cRNA"
+                     /isolate="Ebola
+                     virus/H.sapiens-tc/COD/1976/Yambuku-Mayinga"
+                     /db_xref="taxon:186538"
+     5'UTR           1..55
+                     /note="leader region"
+                     /citation=[1]
+                     /function="regulation or initiation of RNA replication"
+     gene            56..3026
+                     /gene="NP"
+                     /locus_tag="ZEBOVgp1"
+                     /db_xref="GeneID:911830"
+     mRNA            56..3026
+                     /gene="NP"
+                     /locus_tag="ZEBOVgp1"
+                     /product="nucleoprotein"
+                     /db_xref="GeneID:911830"
+     regulatory      56..67
+                     /regulatory_class="other"
+                     /gene="NP"
+                     /locus_tag="ZEBOVgp1"
+                     /note="putative; transcription start signal"
+                     /citation=[1]
+     CDS             470..2689
+                     /gene="NP"
+                     /locus_tag="ZEBOVgp1"
+                     /function="encapsidation of genomic RNA"
+                     /codon_start=1
+                     /product="nucleoprotein"
+                     /protein_id="NP_066243.1"
+                     /db_xref="GeneID:911830"
+                     /translation="MDSRPQKIWMAPSLTESDMDYHKILTAGLSVQQGIVRQRVIPVY
+                     QVNNLEEICQLIIQAFEAGVDFQESADSFLLMLCLHHAYQGDYKLFLESGAVKYLEGH
+                     GFRFEVKKRDGVKRLEELLPAVSSGKNIKRTLAAMPEEETTEANAGQFLSFASLFLPK
+                     LVVGEKACLEKVQRQIQVHAEQGLIQYPTAWQSVGHMMVIFRLMRTNFLIKFLLIHQG
+                     MHMVAGHDANDAVISNSVAQARFSGLLIVKTVLDHILQKTERGVRLHPLARTAKVKNE
+                     VNSFKAALSSLAKHGEYAPFARLLNLSGVNNLEHGLFPQLSAIALGVATAHGSTLAGV
+                     NVGEQYQQLREAATEAEKQLQQYAESRELDHLGLDDQEKKILMNFHQKKNEISFQQTN
+                     AMVTLRKERLAKLTEAITAASLPKTSGHYDDDDDIPFPGPINDDDNPGHQDDDPTDSQ
+                     DTTIPDVVVDPDDGSYGEYQSYSENGMNAPDDLVLFDLDEDDEDTKPVPNRSTKGGQQ
+                     KNSQKGQHIEGRQTQSRPIQNVPGPHRTIHHASAPLTDNDRRNEPSGSTSPRMLTPIN
+                     EEADPLDDADDETSSLPPLESDDEEQDRDGTSNRTPTVAPPAPVYRDHSEKKELPQDE
+                     QQDQDHTQEARNQDSDNTQSEHSFEEMYRHILRSQGPFDAVLYYHMMKDEPVVFSTSD
+                     GKEYTYPDSLEEEYPPWLTEKEAMNEENRFVTLDGQQFYWPVMNHKNKFMAILQHHQ"
+     regulatory      3015..3026
+                     /regulatory_class="polyA_signal_sequence"
+                     /gene="NP"
+                     /locus_tag="ZEBOVgp1"
+     misc_feature    3027..3031
+                     /note="intergenic region"
+     gene            3032..4407
+                     /gene="VP35"
+                     /locus_tag="ZEBOVgp2"
+                     /db_xref="GeneID:911827"
+     mRNA            3032..4407
+                     /gene="VP35"
+                     /locus_tag="ZEBOVgp2"
+                     /product="VP35"
+                     /citation=[5]
+                     /db_xref="GeneID:911827"
+     regulatory      3032..3043
+                     /regulatory_class="other"
+                     /gene="VP35"
+                     /locus_tag="ZEBOVgp2"
+                     /note="putative; transcription start signal"
+                     /citation=[5]
+     CDS             3129..4151
+                     /gene="VP35"
+                     /locus_tag="ZEBOVgp2"
+                     /function="RNA-dependent RNA polymerase cofactor"
+                     /citation=[5]
+                     /codon_start=1
+                     /product="polymerase complex protein"
+                     /protein_id="NP_066244.1"
+                     /db_xref="GeneID:911827"
+                     /translation="MTTRTKGRGHTAATTQNDRMPGPELSGWISEQLMTGRIPVSDIF
+                     CDIENNPGLCYASQMQQTKPNPKTRNSQTQTDPICNHSFEEVVQTLASLATVVQQQTI
+                     ASESLEQRITSLENGLKPVYDMAKTISSLNRVCAEMVAKYDLLVMTTGRATATAAATE
+                     AYWAEHGQPPPGPSLYEESAIRGKIESRDETVPQSVREAFNNLNSTTSLTEENFGKPD
+                     ISAKDLRNIMYDHLPGFGTAFHQLVQVICKLGKDSNSLDIIHAEFQASLAEGDSPQCA
+                     LIQITKRVPIFQDAAPPVIHIRSRGDIPRACQKSLRPVPPSPKIDRGWVCVFQLQDGK
+                     TLGLKI"
+     gene            4390..5894
+                     /gene="VP40"
+                     /locus_tag="ZEBOVgp3"
+                     /db_xref="GeneID:911825"
+     mRNA            4390..5894
+                     /gene="VP40"
+                     /locus_tag="ZEBOVgp3"
+                     /product="VP40"
+                     /citation=[5]
+                     /db_xref="GeneID:911825"
+     regulatory      4390..4401
+                     /regulatory_class="other"
+                     /gene="VP40"
+                     /locus_tag="ZEBOVgp3"
+                     /note="transcription start signal"
+                     /citation=[5]
+     regulatory      4397..4407
+                     /regulatory_class="polyA_signal_sequence"
+                     /gene="VP35"
+                     /locus_tag="ZEBOVgp2"
+                     /citation=[5]
+     CDS             4479..5459
+                     /gene="VP40"
+                     /locus_tag="ZEBOVgp3"
+                     /note="coalesce nucleocapsids and cell membranes in virion
+                     assembly (budding)"
+                     /citation=[5]
+                     /codon_start=1
+                     /product="matrix protein"
+                     /protein_id="NP_066245.1"
+                     /db_xref="GeneID:911825"
+                     /translation="MRRVILPTAPPEYMEAIYPVRSNSTIARGGNSNTGFLTPESVNG
+                     DTPSNPLRPIADDTIDHASHTPGSVSSAFILEAMVNVISGPKVLMKQIPIWLPLGVAD
+                     QKTYSFDSTTAAIMLASYTITHFGKATNPLVRVNRLGPGIPDHPLRLLRIGNQAFLQE
+                     FVLPPVQLPQYFTFDLTALKLITQPLPAATWTDDTPTGSNGALRPGISFHPKLRPILL
+                     PNKSGKKGNSADLTSPEKIQAIMTSLQDFKIVPIDPTKNIMGIEVPETLVHKLTGKKV
+                     TSKNGQPIIPVLLPKYIGLDPVAPGDLTMVITQDCDTCHSPASLPAVIEK"
+     regulatory      5883..5894
+                     /regulatory_class="polyA_signal_sequence"
+                     /gene="VP40"
+                     /locus_tag="ZEBOVgp3"
+                     /citation=[5]
+     misc_feature    5895..5899
+                     /note="intergenic region"
+     gene            5900..8305
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /db_xref="GeneID:911829"
+     mRNA            5900..8305
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /product="sGP"
+                     /note="unedited mRNA"
+                     /citation=[4]
+                     /db_xref="GeneID:911829"
+     regulatory      5900..5911
+                     /regulatory_class="other"
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /note="putative; transcription start signal"
+                     /citation=[4]
+     CDS             join(6039..6923,6923..8068)
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /function="receptor binding and fusion"
+                     /exception="RNA editing"
+                     /note="virion spike glycoprotein precursor; an additional
+                     A residue is inserted during transcription; encodes two
+                     disulfide linked subunits GP1 and GP2"
+                     /citation=[2]
+                     /citation=[3]
+                     /citation=[4]
+                     /codon_start=1
+                     /product="spike glycoprotein"
+                     /protein_id="NP_066246.1"
+                     /db_xref="GeneID:911829"
+                     /translation="MGVTGILQLPRDRFKRTSFFLWVIILFQRTFSIPLGVIHNSTLQ
+                     VSDVDKLVCRDKLSSTNQLRSVGLNLEGNGVATDVPSATKRWGFRSGVPPKVVNYEAG
+                     EWAENCYNLEIKKPDGSECLPAAPDGIRGFPRCRYVHKVSGTGPCAGDFAFHKEGAFF
+                     LYDRLASTVIYRGTTFAEGVVAFLILPQAKKDFFSSHPLREPVNATEDPSSGYYSTTI
+                     RYQATGFGTNETEYLFEVDNLTYVQLESRFTPQFLLQLNETIYTSGKRSNTTGKLIWK
+                     VNPEIDTTIGEWAFWETKKNLTRKIRSEELSFTVVSNGAKNISGQSPARTSSDPGTNT
+                     TTEDHKIMASENSSAMVQVHSQGREAAVSHLTTLATISTSPQSLTTKPGPDNSTHNTP
+                     VYKLDISEATQVEQHHRRTDNDSTASDTPSATTAAGPPKAENTNTSKSTDFLDPATTT
+                     SPQNHSETAGNNNTHHQDTGEESASSGKLGLITNTIAGVAGLITGGRRTRREAIVNAQ
+                     PKCNPNLHYWTTQDEGAAIGLAWIPYFGPAAEGIYIEGLMHNQDGLICGLRQLANETT
+                     QALQLFLRATTELRTFSILNRKAIDFLLQRWGGTCHILGPDCCIEPHDWTKNITDKID
+                     QIIHDFVDKTLPDQGDNDNWWTGWRQWIPAGIGVTGVIIAVIALFCICKFVF"
+     misc_feature    7529..7540
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /note="encodes the glycoprotein cleavage site, precursor
+                     GP is cleaved by subtilisin-like cellular protease furin
+                     into subunits GP1 and GP2 that are linked by a disulfide
+                     bond"
+                     /citation=[3]
+     misc_feature    7793..7870
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /note="immunosuppressive motif; other site"
+     misc_feature    7988..8053
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /note="transmembrane anchor; transmembrane region"
+     CDS             6039..7133
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /note="small non-structural secreted glycoprotein; sGP;
+                     sGP, small non-structural, secreted glycoprotein; sGP
+                     secreted as an anti-parallel oriented homodimer"
+                     /citation=[4]
+                     /codon_start=1
+                     /product="small secreted glycoprotein"
+                     /protein_id="NP_066247.1"
+                     /db_xref="GeneID:911829"
+                     /translation="MGVTGILQLPRDRFKRTSFFLWVIILFQRTFSIPLGVIHNSTLQ
+                     VSDVDKLVCRDKLSSTNQLRSVGLNLEGNGVATDVPSATKRWGFRSGVPPKVVNYEAG
+                     EWAENCYNLEIKKPDGSECLPAAPDGIRGFPRCRYVHKVSGTGPCAGDFAFHKEGAFF
+                     LYDRLASTVIYRGTTFAEGVVAFLILPQAKKDFFSSHPLREPVNATEDPSSGYYSTTI
+                     RYQATGFGTNETEYLFEVDNLTYVQLESRFTPQFLLQLNETIYTSGKRSNTTGKLIWK
+                     VNPEIDTTIGEWAFWETKKTSLEKFAVKSCLSQLYQTEPKTSVVRVRRELLPTQGPTQ
+                     QLKTTKSWLQKIPLQWFKCTVKEGKLQCRI"
+     CDS             join(6039..6922,6924..6933)
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /exception="RNA editing"
+                     /note="ssGP; second non-structural secreted glycoprotein;
+                     super small secreted glycoprotein; secreted in a monomeric
+                     form; one A residue is deleted or two additional A
+                     residues are inserted at the editing site during
+                     transcription of the GP gene"
+                     /citation=[4]
+                     /codon_start=1
+                     /product="second secreted glycoprotein"
+                     /protein_id="NP_066248.1"
+                     /db_xref="GeneID:911829"
+                     /translation="MGVTGILQLPRDRFKRTSFFLWVIILFQRTFSIPLGVIHNSTLQ
+                     VSDVDKLVCRDKLSSTNQLRSVGLNLEGNGVATDVPSATKRWGFRSGVPPKVVNYEAG
+                     EWAENCYNLEIKKPDGSECLPAAPDGIRGFPRCRYVHKVSGTGPCAGDFAFHKEGAFF
+                     LYDRLASTVIYRGTTFAEGVVAFLILPQAKKDFFSSHPLREPVNATEDPSSGYYSTTI
+                     RYQATGFGTNETEYLFEVDNLTYVQLESRFTPQFLLQLNETIYTSGKRSNTTGKLIWK
+                     VNPEIDTTIGEWAFWETKKPH"
+     regulatory      6918..6924
+                     /regulatory_class="other"
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /note="additional A residues are inserted or deleted
+                     during transcription of the GP gene by the viral
+                     polymerase"
+                     /citation=[4]
+                     /function="RNA editing"
+     gene            8288..9740
+                     /gene="VP30"
+                     /locus_tag="ZEBOVgp5"
+                     /db_xref="GeneID:911826"
+     mRNA            8288..9740
+                     /gene="VP30"
+                     /locus_tag="ZEBOVgp5"
+                     /product="VP30"
+                     /db_xref="GeneID:911826"
+     regulatory      8288..8299
+                     /regulatory_class="other"
+                     /gene="VP30"
+                     /locus_tag="ZEBOVgp5"
+                     /note="putative; transcription start signal"
+     regulatory      8295..8305
+                     /regulatory_class="polyA_signal_sequence"
+                     /gene="GP"
+                     /locus_tag="ZEBOVgp4"
+                     /citation=[4]
+     CDS             8509..9375
+                     /gene="VP30"
+                     /locus_tag="ZEBOVgp5"
+                     /function="encapsidation of genomic RNA"
+                     /note="polymerase complex protein"
+                     /codon_start=1
+                     /product="minor nucleoprotein"
+                     /protein_id="NP_066249.1"
+                     /db_xref="GeneID:911826"
+                     /translation="MEASYERGRPRAARQHSRDGHDHHVRARSSSRENYRGEYRQSRS
+                     ASQVRVPTVFHKKRVEPLTVPPAPKDICPTLKKGFLCDSSFCKKDHQLESLTDRELLL
+                     LIARKTCGSVEQQLNITAPKDSRLANPTADDFQQEEGPKITLLTLIKTAEHWARQDIR
+                     TIEDSKLRALLTLCAVMTRKFSKSQLSLLCETHLRREGLGQDQAEPVLEVYQRLHSDK
+                     GGSFEAALWQQWDRQSLIMFITAFLNIALQLPCESSAVVVSGLRTLVPQSDNEEASTN
+                     PGTCSWSDEGTP"
+     regulatory      9730..9740
+                     /regulatory_class="polyA_signal_sequence"
+                     /gene="VP30"
+                     /locus_tag="ZEBOVgp5"
+                     /note="putative"
+     misc_feature    9741..9884
+                     /note="intergenic region"
+     gene            9885..11518
+                     /gene="VP24"
+                     /locus_tag="ZEBOVgp6"
+                     /note="putative"
+                     /db_xref="GeneID:911828"
+     mRNA            9885..11496
+                     /gene="VP24"
+                     /locus_tag="ZEBOVgp6"
+                     /product="VP24"
+                     /db_xref="GeneID:911828"
+     regulatory      9885..9896
+                     /regulatory_class="other"
+                     /gene="VP24"
+                     /locus_tag="ZEBOVgp6"
+                     /note="transcription start signal"
+     CDS             10345..11100
+                     /gene="VP24"
+                     /locus_tag="ZEBOVgp6"
+                     /codon_start=1
+                     /product="membrane-associated protein"
+                     /protein_id="NP_066250.1"
+                     /db_xref="GeneID:911828"
+                     /translation="MAKATGRYNLISPKKDLEKGVVLSDLCNFLVSQTIQGWKVYWAG
+                     IEFDVTHKGMALLHRLKTNDFAPAWSMTRNLFPHLFQNPNSTIESPLWALRVILAAGI
+                     QDQLIDQSLIEPLAGALGLISDWLLTTNTNHFNMRTQRVKEQLSLKMLSLIRSNILKF
+                     INKLDALHVVNYNGLLSSIEIGTQNHTIIITRTNMGFLVELQEPDKSAMNRMKPGPAK
+                     FSLLHESTLKAFTQGSSTRMQSLILEFNSSLAI"
+     regulatory      11485..11496
+                     /regulatory_class="polyA_signal_sequence"
+                     /gene="VP24"
+                     /locus_tag="ZEBOVgp6"
+                     /note="putative"
+     misc_feature    11497..11500
+                     /gene="VP24"
+                     /locus_tag="ZEBOVgp6"
+                     /note="intergenic region"
+     gene            11501..18282
+                     /gene="L"
+                     /locus_tag="ZEBOVgp7"
+                     /db_xref="GeneID:911824"
+     mRNA            11501..18282
+                     /gene="L"
+                     /locus_tag="ZEBOVgp7"
+                     /product="polymerase"
+                     /citation=[1]
+                     /db_xref="GeneID:911824"
+     regulatory      11501..11512
+                     /regulatory_class="other"
+                     /gene="L"
+                     /locus_tag="ZEBOVgp7"
+                     /note="transcription start signal"
+                     /citation=[1]
+     regulatory      11508..11518
+                     /regulatory_class="polyA_signal_sequence"
+                     /gene="VP24"
+                     /locus_tag="ZEBOVgp6"
+     CDS             11581..18219
+                     /gene="L"
+                     /locus_tag="ZEBOVgp7"
+                     /function="synthesis of viral RNAs; transcriptional RNA
+                     editing"
+                     /citation=[1]
+                     /codon_start=1
+                     /product="RNA-dependent RNA polymerase"
+                     /protein_id="NP_066251.1"
+                     /db_xref="GeneID:911824"
+                     /translation="MATQHTQYPDARLSSPIVLDQCDLVTRACGLYSSYSLNPQLRNC
+                     KLPKHIYRLKYDVTVTKFLSDVPVATLPIDFIVPVLLKALSGNGFCPVEPRCQQFLDE
+                     IIKYTMQDALFLKYYLKNVGAQEDCVDEHFQEKILSSIQGNEFLHQMFFWYDLAILTR
+                     RGRLNRGNSRSTWFVHDDLIDILGYGDYVFWKIPISMLPLNTQGIPHAAMDWYQASVF
+                     KEAVQGHTHIVSVSTADVLIMCKDLITCRFNTTLISKIAEIEDPVCSDYPNFKIVSML
+                     YQSGDYLLSILGSDGYKIIKFLEPLCLAKIQLCSKYTERKGRFLTQMHLAVNHTLEEI
+                     TEMRALKPSQAQKIREFHRTLIRLEMTPQQLCELFSIQKHWGHPVLHSETAIQKVKKH
+                     ATVLKALRPIVIFETYCVFKYSIAKHYFDSQGSWYSVTSDRNLTPGLNSYIKRNQFPP
+                     LPMIKELLWEFYHLDHPPLFSTKIISDLSIFIKDRATAVERTCWDAVFEPNVLGYNPP
+                     HKFSTKRVPEQFLEQENFSIENVLSYAQKLEYLLPQYRNFSFSLKEKELNVGRTFGKL
+                     PYPTRNVQTLCEALLADGLAKAFPSNMMVVTEREQKESLLHQASWHHTSDDFGEHATV
+                     RGSSFVTDLEKYNLAFRYEFTAPFIEYCNRCYGVKNVFNWMHYTIPQCYMHVSDYYNP
+                     PHNLTLENRDNPPEGPSSYRGHMGGIEGLQQKLWTSISCAQISLVEIKTGFKLRSAVM
+                     GDNQCITVLSVFPLETDADEQEQSAEDNAARVAASLAKVTSACGIFLKPDETFVHSGF
+                     IYFGKKQYLNGVQLPQSLKTATRMAPLSDAIFDDLQGTLASIGTAFERSISETRHIFP
+                     CRITAAFHTFFSVRILQYHHLGFNKGFDLGQLTLGKPLDFGTISLALAVPQVLGGLSF
+                     LNPEKCFYRNLGDPVTSGLFQLKTYLRMIEMDDLFLPLIAKNPGNCTAIDFVLNPSGL
+                     NVPGSQDLTSFLRQIVRRTITLSAKNKLINTLFHASADFEDEMVCKWLLSSTPVMSRF
+                     AADIFSRTPSGKRLQILGYLEGTRTLLASKIINNNTETPVLDRLRKITLQRWSLWFSY
+                     LDHCDNILAEALTQITCTVDLAQILREYSWAHILEGRPLIGATLPCMIEQFKVFWLKP
+                     YEQCPQCSNAKQPGGKPFVSVAVKKHIVSAWPNASRISWTIGDGIPYIGSRTEDKIGQ
+                     PAIKPKCPSAALREAIELASRLTWVTQGSSNSDLLIKPFLEARVNLSVQEILQMTPSH
+                     YSGNIVHRYNDQYSPHSFMANRMSNSATRLIVSTNTLGEFSGGGQSARDSNIIFQNVI
+                     NYAVALFDIKFRNTEATDIQYNRAHLHLTKCCTREVPAQYLTYTSTLDLDLTRYRENE
+                     LIYDSNPLKGGLNCNISFDNPFFQGKRLNIIEDDLIRLPHLSGWELAKTIMQSIISDS
+                     NNSSTDPISSGETRSFTTHFLTYPKIGLLYSFGAFVSYYLGNTILRTKKLTLDNFLYY
+                     LTTQIHNLPHRSLRILKPTFKHASVMSRLMSIDPHFSIYIGGAAGDRGLSDAARLFLR
+                     TSISSFLTFVKEWIINRGTIVPLWIVYPLEGQNPTPVNNFLYQIVELLVHDSSRQQAF
+                     KTTISDHVHPHDNLVYTCKSTASNFFHASLAYWRSRHRNSNRKYLARDSSTGSSTNNS
+                     DGHIERSQEQTTRDPHDGTERNLVLQMSHEIKRTTIPQENTHQGPSFQSFLSDSACGT
+                     ANPKLNFDRSRHNVKFQDHNSASKREGHQIISHRLVLPFFTLSQGTRQLTSSNESQTQ
+                     DEISKYLRQLRSVIDTTVYCRFTGIVSSMHYKLDEVLWEIESFKSAVTLAEGEGAGAL
+                     LLIQKYQVKTLFFNTLATESSIESEIVSGMTTPRMLLPVMSKFHNDQIEIILNNSASQ
+                     ITDITNPTWFKDQRARLPKQVEVITMDAETTENINRSKLYEAVYKLILHHIDPSVLKA
+                     VVLKVFLSDTEGMLWLNDNLAPFFATGYLIKPITSSARSSEWYLCLTNFLSTTRKMPH
+                     QNHLSCKQVILTALQLQIQRSPYWLSHLTQYADCELHLSYIRLGFPSLEKVLYHRYNL
+                     VDSKRGPLVSITQHLAHLRAEIRELTNDYNQQRQSRTQTYHFIRTAKGRITKLVNDYL
+                     KFFLIVQALKHNGTWQAEFKKLPELISVCNRFYHIRDCNCEERFLVQTLYLHRMQDSE
+                     VKLIERLTGLLSLFPDGLYRFD"
+     regulatory      18272..18282
+                     /regulatory_class="polyA_signal_sequence"
+                     /gene="L"
+                     /locus_tag="ZEBOVgp7"
+                     /citation=[1]
+     3'UTR           18283..18959
+                     /note="trailer region"
+                     /citation=[1]
+                     /function="regulation or initiation of RNA replication"
+ORIGIN      
+        1 cggacacaca aaaagaaaga agaattttta ggatcttttg tgtgcgaata actatgagga
+       61 agattaataa ttttcctctc attgaaattt atatcggaat ttaaattgaa attgttactg
+      121 taatcacacc tggtttgttt cagagccaca tcacaaagat agagaacaac ctaggtctcc
+      181 gaagggagca agggcatcag tgtgctcagt tgaaaatccc ttgtcaacac ctaggtctta
+      241 tcacatcaca agttccacct cagactctgc agggtgatcc aacaacctta atagaaacat
+      301 tattgttaaa ggacagcatt agttcacagt caaacaagca agattgagaa ttaaccttgg
+      361 ttttgaactt gaacacttag gggattgaag attcaacaac cctaaagctt ggggtaaaac
+      421 attggaaata gttaaaagac aaattgctcg gaatcacaaa attccgagta tggattctcg
+      481 tcctcagaaa atctggatgg cgccgagtct cactgaatct gacatggatt accacaagat
+      541 cttgacagca ggtctgtccg ttcaacaggg gattgttcgg caaagagtca tcccagtgta
+      601 tcaagtaaac aatcttgaag aaatttgcca acttatcata caggcctttg aagcaggtgt
+      661 tgattttcaa gagagtgcgg acagtttcct tctcatgctt tgtcttcatc atgcgtacca
+      721 gggagattac aaacttttct tggaaagtgg cgcagtcaag tatttggaag ggcacgggtt
+      781 ccgttttgaa gtcaagaagc gtgatggagt gaagcgcctt gaggaattgc tgccagcagt
+      841 atctagtgga aaaaacatta agagaacact tgctgccatg ccggaagagg agacaactga
+      901 agctaatgcc ggtcagtttc tctcctttgc aagtctattc cttccgaaat tggtagtagg
+      961 agaaaaggct tgccttgaga aggttcaaag gcaaattcaa gtacatgcag agcaaggact
+     1021 gatacaatat ccaacagctt ggcaatcagt aggacacatg atggtgattt tccgtttgat
+     1081 gcgaacaaat tttctgatca aatttctcct aatacaccaa gggatgcaca tggttgccgg
+     1141 gcatgatgcc aacgatgctg tgatttcaaa ttcagtggct caagctcgtt tttcaggctt
+     1201 attgattgtc aaaacagtac ttgatcatat cctacaaaag acagaacgag gagttcgtct
+     1261 ccatcctctt gcaaggaccg ccaaggtaaa aaatgaggtg aactccttta aggctgcact
+     1321 cagctccctg gccaagcatg gagagtatgc tcctttcgcc cgacttttga acctttctgg
+     1381 agtaaataat cttgagcatg gtcttttccc tcaactatcg gcaattgcac tcggagtcgc
+     1441 cacagcacac gggagtaccc tcgcaggagt aaatgttgga gaacagtatc aacaactcag
+     1501 agaggctgcc actgaggctg agaagcaact ccaacaatat gcagagtctc gcgaacttga
+     1561 ccatcttgga cttgatgatc aggaaaagaa aattcttatg aacttccatc agaaaaagaa
+     1621 cgaaatcagc ttccagcaaa caaacgctat ggtaactcta agaaaagagc gcctggccaa
+     1681 gctgacagaa gctatcactg ctgcgtcact gcccaaaaca agtggacatt acgatgatga
+     1741 tgacgacatt ccctttccag gacccatcaa tgatgacgac aatcctggcc atcaagatga
+     1801 tgatccgact gactcacagg atacgaccat tcccgatgtg gtggttgatc ccgatgatgg
+     1861 aagctacggc gaataccaga gttactcgga aaacggcatg aatgcaccag atgacttggt
+     1921 cctattcgat ctagacgagg acgacgagga cactaagcca gtgcctaata gatcgaccaa
+     1981 gggtggacaa cagaagaaca gtcaaaaggg ccagcatata gagggcagac agacacaatc
+     2041 caggccaatt caaaatgtcc caggccctca cagaacaatc caccacgcca gtgcgccact
+     2101 cacggacaat gacagaagaa atgaaccctc cggctcaacc agccctcgca tgctgacacc
+     2161 aattaacgaa gaggcagacc cactggacga tgccgacgac gagacgtcta gccttccgcc
+     2221 cttggagtca gatgatgaag agcaggacag ggacggaact tccaaccgca cacccactgt
+     2281 cgccccaccg gctcccgtat acagagatca ctctgaaaag aaagaactcc cgcaagacga
+     2341 gcaacaagat caggaccaca ctcaagaggc caggaaccag gacagtgaca acacccagtc
+     2401 agaacactct tttgaggaga tgtatcgcca cattctaaga tcacaggggc catttgatgc
+     2461 tgttttgtat tatcatatga tgaaggatga gcctgtagtt ttcagtacca gtgatggcaa
+     2521 agagtacacg tatccagact cccttgaaga ggaatatcca ccatggctca ctgaaaaaga
+     2581 ggctatgaat gaagagaata gatttgttac attggatggt caacaatttt attggccggt
+     2641 gatgaatcac aagaataaat tcatggcaat cctgcaacat catcagtgaa tgagcatgga
+     2701 acaatgggat gattcaaccg acaaatagct aacattaagt agtcaaggaa cgaaaacagg
+     2761 aagaattttt gatgtctaag gtgtgaatta ttatcacaat aaaagtgatt cttatttttg
+     2821 aatttaaagc tagcttatta ttactagccg tttttcaaag ttcaatttga gtcttaatgc
+     2881 aaataggcgt taagccacag ttatagccat aattgtaact caatattcta actagcgatt
+     2941 tatctaaatt aaattacatt atgcttttat aacttaccta ctagcctgcc caacatttac
+     3001 acgatcgttt tataattaag aaaaaactaa tgatgaagat taaaaccttc atcatcctta
+     3061 cgtcaattga attctctagc actcgaagct tattgtcttc aatgtaaaag aaaagctggt
+     3121 ctaacaagat gacaactaga acaaagggca ggggccatac tgcggccacg actcaaaacg
+     3181 acagaatgcc aggccctgag ctttcgggct ggatctctga gcagctaatg accggaagaa
+     3241 ttcctgtaag cgacatcttc tgtgatattg agaacaatcc aggattatgc tacgcatccc
+     3301 aaatgcaaca aacgaagcca aacccgaaga cgcgcaacag tcaaacccaa acggacccaa
+     3361 tttgcaatca tagttttgag gaggtagtac aaacattggc ttcattggct actgttgtgc
+     3421 aacaacaaac catcgcatca gaatcattag aacaacgcat tacgagtctt gagaatggtc
+     3481 taaagccagt ttatgatatg gcaaaaacaa tctcctcatt gaacagggtt tgtgctgaga
+     3541 tggttgcaaa atatgatctt ctggtgatga caaccggtcg ggcaacagca accgctgcgg
+     3601 caactgaggc ttattgggcc gaacatggtc aaccaccacc tggaccatca ctttatgaag
+     3661 aaagtgcgat tcggggtaag attgaatcta gagatgagac cgtccctcaa agtgttaggg
+     3721 aggcattcaa caatctaaac agtaccactt cactaactga ggaaaatttt gggaaacctg
+     3781 acatttcggc aaaggatttg agaaacatta tgtatgatca cttgcctggt tttggaactg
+     3841 ctttccacca attagtacaa gtgatttgta aattgggaaa agatagcaac tcattggaca
+     3901 tcattcatgc tgagttccag gccagcctgg ctgaaggaga ctctcctcaa tgtgccctaa
+     3961 ttcaaattac aaaaagagtt ccaatcttcc aagatgctgc tccacctgtc atccacatcc
+     4021 gctctcgagg tgacattccc cgagcttgcc agaaaagctt gcgtccagtc ccaccatcgc
+     4081 ccaagattga tcgaggttgg gtatgtgttt ttcagcttca agatggtaaa acacttggac
+     4141 tcaaaatttg agccaatctc ccttccctcc gaaagaggcg aataatagca gaggcttcaa
+     4201 ctgctgaact atagggtacg ttacattaat gatacacttg tgagtatcag ccctggataa
+     4261 tataagtcaa ttaaacgacc aagataaaat tgttcatatc tcgctagcag cttaaaatat
+     4321 aaatgtaata ggagctatat ctctgacagt attataatca attgttatta agtaacccaa
+     4381 accaaaagtg atgaagatta agaaaaacct acctcggctg agagagtgtt ttttcattaa
+     4441 ccttcatctt gtaaacgttg agcaaaattg ttaaaaatat gaggcgggtt atattgccta
+     4501 ctgctcctcc tgaatatatg gaggccatat accctgtcag gtcaaattca acaattgcta
+     4561 gaggtggcaa cagcaataca ggcttcctga caccggagtc agtcaatggg gacactccat
+     4621 cgaatccact caggccaatt gccgatgaca ccatcgacca tgccagccac acaccaggca
+     4681 gtgtgtcatc agcattcatc cttgaagcta tggtgaatgt catatcgggc cccaaagtgc
+     4741 taatgaagca aattccaatt tggcttcctc taggtgtcgc tgatcaaaag acctacagct
+     4801 ttgactcaac tacggccgcc atcatgcttg cttcatacac tatcacccat ttcggcaagg
+     4861 caaccaatcc acttgtcaga gtcaatcggc tgggtcctgg aatcccggat catcccctca
+     4921 ggctcctgcg aattggaaac caggctttcc tccaggagtt cgttcttccg ccagtccaac
+     4981 taccccagta tttcaccttt gatttgacag cactcaaact gatcacccaa ccactgcctg
+     5041 ctgcaacatg gaccgatgac actccaacag gatcaaatgg agcgttgcgt ccaggaattt
+     5101 catttcatcc aaaacttcgc cccattcttt tacccaacaa aagtgggaag aaggggaaca
+     5161 gtgccgatct aacatctccg gagaaaatcc aagcaataat gacttcactc caggacttta
+     5221 agatcgttcc aattgatcca accaaaaata tcatgggaat cgaagtgcca gaaactctgg
+     5281 tccacaagct gaccggtaag aaggtgactt ctaaaaatgg acaaccaatc atccctgttc
+     5341 ttttgccaaa gtacattggg ttggacccgg tggctccagg agacctcacc atggtaatca
+     5401 cacaggattg tgacacgtgt cattctcctg caagtcttcc agctgtgatt gagaagtaat
+     5461 tgcaataatt gactcagatc cagttttata gaatcttctc agggatagtg ataacatcta
+     5521 tttagtaatc cgtccattag aggagacact tttaattgat caatatacta aaggtgcttt
+     5581 acaccattgt cttttttctc tcctaaatgt agaacttaac aaaagactca taatatactt
+     5641 gtttttaaag gattgattga tgaaagatca taactaataa cattacaaat aatcctacta
+     5701 taatcaatac ggtgattcaa atgttaatct ttctcattgc acatactttt tgcccttatc
+     5761 ctcaaattgc ctgcatgctt acatctgagg atagccagtg tgacttggat tggaaatgtg
+     5821 gagaaaaaat cgggacccat ttctaggttg ttcacaatcc aagtacagac attgcccttc
+     5881 taattaagaa aaaatcggcg atgaagatta agccgacagt gagcgtaatc ttcatctctc
+     5941 ttagattatt tgttttccag agtaggggtc gtcaggtcct tttcaatcgt gtaaccaaaa
+     6001 taaactccac tagaaggata ttgtggggca acaacacaat gggcgttaca ggaatattgc
+     6061 agttacctcg tgatcgattc aagaggacat cattctttct ttgggtaatt atccttttcc
+     6121 aaagaacatt ttccatccca cttggagtca tccacaatag cacattacag gttagtgatg
+     6181 tcgacaaact agtttgtcgt gacaaactgt catccacaaa tcaattgaga tcagttggac
+     6241 tgaatctcga agggaatgga gtggcaactg acgtgccatc tgcaactaaa agatggggct
+     6301 tcaggtccgg tgtcccacca aaggtggtca attatgaagc tggtgaatgg gctgaaaact
+     6361 gctacaatct tgaaatcaaa aaacctgacg ggagtgagtg tctaccagca gcgccagacg
+     6421 ggattcgggg cttcccccgg tgccggtatg tgcacaaagt atcaggaacg ggaccgtgtg
+     6481 ccggagactt tgccttccat aaagagggtg ctttcttcct gtatgatcga cttgcttcca
+     6541 cagttatcta ccgaggaacg actttcgctg aaggtgtcgt tgcatttctg atactgcccc
+     6601 aagctaagaa ggacttcttc agctcacacc ccttgagaga gccggtcaat gcaacggagg
+     6661 acccgtctag tggctactat tctaccacaa ttagatatca ggctaccggt tttggaacca
+     6721 atgagacaga gtacttgttc gaggttgaca atttgaccta cgtccaactt gaatcaagat
+     6781 tcacaccaca gtttctgctc cagctgaatg agacaatata tacaagtggg aaaaggagca
+     6841 ataccacggg aaaactaatt tggaaggtca accccgaaat tgatacaaca atcggggagt
+     6901 gggccttctg ggaaactaaa aaaacctcac tagaaaaatt cgcagtgaag agttgtcttt
+     6961 cacagttgta tcaaacggag ccaaaaacat cagtggtcag agtccggcgc gaacttcttc
+     7021 cgacccaggg accaacacaa caactgaaga ccacaaaatc atggcttcag aaaattcctc
+     7081 tgcaatggtt caagtgcaca gtcaaggaag ggaagctgca gtgtcgcatc taacaaccct
+     7141 tgccacaatc tccacgagtc cccaatccct cacaaccaaa ccaggtccgg acaacagcac
+     7201 ccataataca cccgtgtata aacttgacat ctctgaggca actcaagttg aacaacatca
+     7261 ccgcagaaca gacaacgaca gcacagcctc cgacactccc tctgccacga ccgcagccgg
+     7321 acccccaaaa gcagagaaca ccaacacgag caagagcact gacttcctgg accccgccac
+     7381 cacaacaagt ccccaaaacc acagcgagac cgctggcaac aacaacactc atcaccaaga
+     7441 taccggagaa gagagtgcca gcagcgggaa gctaggctta attaccaata ctattgctgg
+     7501 agtcgcagga ctgatcacag gcgggagaag aactcgaaga gaagcaattg tcaatgctca
+     7561 acccaaatgc aaccctaatt tacattactg gactactcag gatgaaggtg ctgcaatcgg
+     7621 actggcctgg ataccatatt tcgggccagc agccgaggga atttacatag aggggctaat
+     7681 gcacaatcaa gatggtttaa tctgtgggtt gagacagctg gccaacgaga cgactcaagc
+     7741 tcttcaactg ttcctgagag ccacaactga gctacgcacc ttttcaatcc tcaaccgtaa
+     7801 ggcaattgat ttcttgctgc agcgatgggg cggcacatgc cacattctgg gaccggactg
+     7861 ctgtatcgaa ccacatgatt ggaccaagaa cataacagac aaaattgatc agattattca
+     7921 tgattttgtt gataaaaccc ttccggacca gggggacaat gacaattggt ggacaggatg
+     7981 gagacaatgg ataccggcag gtattggagt tacaggcgtt ataattgcag ttatcgcttt
+     8041 attctgtata tgcaaatttg tcttttagtt tttcttcaga ttgcttcatg gaaaagctca
+     8101 gcctcaaatc aatgaaacca ggatttaatt atatggatta cttgaatcta agattacttg
+     8161 acaaatgata atataataca ctggagcttt aaacatagcc aatgtgattc taactccttt
+     8221 aaactcacag ttaatcataa acaaggtttg acatcaatct agttatctct ttgagaatga
+     8281 taaacttgat gaagattaag aaaaaggtaa tctttcgatt atctttaatc ttcatccttg
+     8341 attctacaat catgacagtt gtctttagtg acaagggaaa gaagcctttt tattaagttg
+     8401 taataatcag atctgcgaac cggtagagtt tagttgcaac ctaacacaca taaagcattg
+     8461 gtcaaaaagt caatagaaat ttaaacagtg agtggagaca acttttaaat ggaagcttca
+     8521 tatgagagag gacgcccacg agctgccaga cagcattcaa gggatggaca cgaccaccat
+     8581 gttcgagcac gatcatcatc cagagagaat tatcgaggtg agtaccgtca atcaaggagc
+     8641 gcctcacaag tgcgcgttcc tactgtattt cataagaaga gagttgaacc attaacagtt
+     8701 cctccagcac ctaaagacat atgtccgacc ttgaaaaaag gatttttgtg tgacagtagt
+     8761 ttttgcaaaa aagatcacca gttggagagt ttaactgata gggaattact cctactaatc
+     8821 gcccgtaaga cttgtggatc agtagaacaa caattaaata taactgcacc caaggactcg
+     8881 cgcttagcaa atccaacggc tgatgatttc cagcaagagg aaggtccaaa aattaccttg
+     8941 ttgacactga tcaagacggc agaacactgg gcgagacaag acatcagaac catagaggat
+     9001 tcaaaattaa gagcattgtt gactctatgt gctgtgatga cgaggaaatt ctcaaaatcc
+     9061 cagctgagtc ttttatgtga gacacaccta aggcgcgagg ggcttgggca agatcaggca
+     9121 gaacccgttc tcgaagtata tcaacgatta cacagtgata aaggaggcag ttttgaagct
+     9181 gcactatggc aacaatggga ccgacaatcc ctaattatgt ttatcactgc attcttgaat
+     9241 attgctctcc agttaccgtg tgaaagttct gctgtcgttg tttcagggtt aagaacattg
+     9301 gttcctcaat cagataatga ggaagcttca accaacccgg ggacatgctc atggtctgat
+     9361 gagggtaccc cttaataagg ctgactaaaa cactatataa ccttctactt gatcacaata
+     9421 ctccgtatac ctatcatcat atatttaatc aagacgatat cctttaaaac ttattcagta
+     9481 ctataatcac tctcgtttca aattaataag atgtgcatga ttgccctaat atatgaagag
+     9541 gtatgataca accctaacag tgatcaaaga aaatcataat ctcgtatcgc tcgtaatata
+     9601 acctgccaag catacctctt gcacaaagtg attcttgtac acaaataatg ttttactcta
+     9661 caggaggtag caacgatcca tcccatcaaa aaataagtat ttcatgactt actaatgatc
+     9721 tcttaaaata ttaagaaaaa ctgacggaac ataaattctt tatgcttcaa gctgtggagg
+     9781 aggtgtttgg tattggctat tgttatatta caatcaataa caagcttgta aaaatattgt
+     9841 tcttgtttca agaggtagat tgtgaccgga aatgctaaac taatgatgaa gattaatgcg
+     9901 gaggtctgat aagaataaac cttattattc agattaggcc ccaagaggca ttcttcatct
+     9961 ccttttagca aagtactatt tcagggtagt ccaattagtg gcacgtcttt tagctgtata
+    10021 tcagtcgccc ctgagatacg ccacaaaagt gtctctaagc taaattggtc tgtacacatc
+    10081 ccatacattg tattaggggc aataatatct aattgaactt agccgtttaa aatttagtgc
+    10141 ataaatctgg gctaacacca ccaggtcaac tccattggct gaaaagaagc ttacctacaa
+    10201 cgaacatcac tttgagcgcc ctcacaatta aaaaatagga acgtcgttcc aacaatcgag
+    10261 cgcaaggttt caaggttgaa ctgagagtgt ctagacaaca aaatattgat actccagaca
+    10321 ccaagcaaga cctgagaaaa aaccatggct aaagctacgg gacgatacaa tctaatatcg
+    10381 cccaaaaagg acctggagaa aggggttgtc ttaagcgacc tctgtaactt cttagttagc
+    10441 caaactattc aggggtggaa ggtttattgg gctggtattg agtttgatgt gactcacaaa
+    10501 ggaatggccc tattgcatag actgaaaact aatgactttg cccctgcatg gtcaatgaca
+    10561 aggaatctct ttcctcattt atttcaaaat ccgaattcca caattgaatc accgctgtgg
+    10621 gcattgagag tcatccttgc agcagggata caggaccagc tgattgacca gtctttgatt
+    10681 gaacccttag caggagccct tggtctgatc tctgattggc tgctaacaac caacactaac
+    10741 catttcaaca tgcgaacaca acgtgtcaag gaacaattga gcctaaaaat gctgtcgttg
+    10801 attcgatcca atattctcaa gtttattaac aaattggatg ctctacatgt cgtgaactac
+    10861 aacggattgt tgagcagtat tgaaattgga actcaaaatc atacaatcat cataactcga
+    10921 actaacatgg gttttctggt ggagctccaa gaacccgaca aatcggcaat gaaccgcatg
+    10981 aagcctgggc cggcgaaatt ttccctcctt catgagtcca cactgaaagc atttacacaa
+    11041 ggatcctcga cacgaatgca aagtttgatt cttgaattta atagctctct tgctatctaa
+    11101 ctaaggtaga atacttcata ttgagctaac tcatatatgc tgactcaata gttatcttga
+    11161 catctctgct ttcataatca gatatataag cataataaat aaatactcat atttcttgat
+    11221 aatttgttta accacagata aatcctcact gtaagccagc ttccaagttg acacccttac
+    11281 aaaaaccagg actcagaatc cctcaaacaa gagattccaa gacaacatca tagaattgct
+    11341 ttattatatg aataagcatt ttatcaccag aaatcctata tactaaatgg ttaattgtaa
+    11401 ctgaacccgc aggtcacatg tgttaggttt cacagattct atatattact aactctatac
+    11461 tcgtaattaa cattagataa gtagattaag aaaaaagcct gaggaagatt aagaaaaact
+    11521 gcttattggg tctttccgtg ttttagatga agcagttgaa attcttcctc ttgatattaa
+    11581 atggctacac aacataccca atacccagac gctaggttat catcaccaat tgtattggac
+    11641 caatgtgacc tagtcactag agcttgcggg ttatattcat catactccct taatccgcaa
+    11701 ctacgcaact gtaaactccc gaaacatatc taccgtttga aatacgatgt aactgttacc
+    11761 aagttcttga gtgatgtacc agtggcgaca ttgcccatag atttcatagt cccagttctt
+    11821 ctcaaggcac tgtcaggcaa tggattctgt cctgttgagc cgcggtgcca acagttctta
+    11881 gatgaaatca ttaagtacac aatgcaagat gctctcttct tgaaatatta tctcaaaaat
+    11941 gtgggtgctc aagaagactg tgttgatgaa cactttcaag agaaaatctt atcttcaatt
+    12001 cagggcaatg aatttttaca tcaaatgttt ttctggtatg atctggctat tttaactcga
+    12061 aggggtagat taaatcgagg aaactctaga tcaacatggt ttgttcatga tgatttaata
+    12121 gacatcttag gctatgggga ctatgttttt tggaagatcc caatttcaat gttaccactg
+    12181 aacacacaag gaatccccca tgctgctatg gactggtatc aggcatcagt attcaaagaa
+    12241 gcggttcaag ggcatacaca cattgtttct gtttctactg ccgacgtctt gataatgtgc
+    12301 aaagatttaa ttacatgtcg attcaacaca actctaatct caaaaatagc agagattgag
+    12361 gatccagttt gttctgatta tcccaatttt aagattgtgt ctatgcttta ccagagcgga
+    12421 gattacttac tctccatatt agggtctgat gggtataaaa ttattaagtt cctcgaacca
+    12481 ttgtgcttgg ccaaaattca attatgctca aagtacactg agaggaaggg ccgattctta
+    12541 acacaaatgc atttagctgt aaatcacacc ctagaagaaa ttacagaaat gcgtgcacta
+    12601 aagccttcac aggctcaaaa gatccgtgaa ttccatagaa cattgataag gctggagatg
+    12661 acgccacaac aactttgtga gctattttcc attcaaaaac actgggggca tcctgtgcta
+    12721 catagtgaaa cagcaatcca aaaagttaaa aaacatgcta cggtgctaaa agcattacgc
+    12781 cctatagtga ttttcgagac atactgtgtt tttaaatata gtattgccaa acattatttt
+    12841 gatagtcaag gatcttggta cagtgttact tcagatagga atctaacacc gggtcttaat
+    12901 tcttatatca aaagaaatca attccctccg ttgccaatga ttaaagaact actatgggaa
+    12961 ttttaccacc ttgaccaccc tccacttttc tcaaccaaaa ttattagtga cttaagtatt
+    13021 tttataaaag acagagctac cgcagtagaa aggacatgct gggatgcagt attcgagcct
+    13081 aatgttctag gatataatcc acctcacaaa tttagtacta aacgtgtacc ggaacaattt
+    13141 ttagagcaag aaaacttttc tattgagaat gttctttcct acgcacaaaa actcgagtat
+    13201 ctactaccac aatatcggaa cttttctttc tcattgaaag agaaagagtt gaatgtaggt
+    13261 agaaccttcg gaaaattgcc ttatccgact cgcaatgttc aaacactttg tgaagctctg
+    13321 ttagctgatg gtcttgctaa agcatttcct agcaatatga tggtagttac ggaacgtgag
+    13381 caaaaagaaa gcttattgca tcaagcatca tggcaccaca caagtgatga ttttggtgaa
+    13441 catgccacag ttagagggag tagctttgta actgatttag agaaatacaa tcttgcattt
+    13501 agatatgagt ttacagcacc ttttatagaa tattgcaacc gttgctatgg tgttaagaat
+    13561 gtttttaatt ggatgcatta tacaatccca cagtgttata tgcatgtcag tgattattat
+    13621 aatccaccac ataacctcac actggagaat cgagacaacc cccccgaagg gcctagttca
+    13681 tacaggggtc atatgggagg gattgaagga ctgcaacaaa aactctggac aagtatttca
+    13741 tgtgctcaaa tttctttagt tgaaattaag actggtttta agttacgctc agctgtgatg
+    13801 ggtgacaatc agtgcattac tgttttatca gtcttcccct tagagactga cgcagacgag
+    13861 caggaacaga gcgccgaaga caatgcagcg agggtggccg ccagcctagc aaaagttaca
+    13921 agtgcctgtg gaatcttttt aaaacctgat gaaacatttg tacattcagg ttttatctat
+    13981 tttggaaaaa aacaatattt gaatggggtc caattgcctc agtcccttaa aacggctaca
+    14041 agaatggcac cattgtctga tgcaattttt gatgatcttc aagggaccct ggctagtata
+    14101 ggcactgctt ttgagcgatc catctctgag acacgacata tctttccttg caggataacc
+    14161 gcagctttcc atacgttttt ttcggtgaga atcttgcaat atcatcatct cgggttcaat
+    14221 aaaggttttg accttggaca gttaacactc ggcaaacctc tggatttcgg aacaatatca
+    14281 ttggcactag cggtaccgca ggtgcttgga gggttatcct tcttgaatcc tgagaaatgt
+    14341 ttctaccgga atctaggaga tccagttacc tcaggcttat tccagttaaa aacttatctc
+    14401 cgaatgattg agatggatga tttattctta cctttaattg cgaagaaccc tgggaactgc
+    14461 actgccattg actttgtgct aaatcctagc ggattaaatg tccctgggtc gcaagactta
+    14521 acttcatttc tgcgccagat tgtacgcagg accatcaccc taagtgcgaa aaacaaactt
+    14581 attaatacct tatttcatgc gtcagctgac ttcgaagacg aaatggtttg taaatggcta
+    14641 ttatcatcaa ctcctgttat gagtcgtttt gcggccgata tcttttcacg cacgccgagc
+    14701 gggaagcgat tgcaaattct aggatacctg gaaggaacac gcacattatt agcctctaag
+    14761 atcatcaaca ataatacaga gacaccggtt ttggacagac tgaggaaaat aacattgcaa
+    14821 aggtggagcc tatggtttag ttatcttgat cattgtgata atatcctggc ggaggcttta
+    14881 acccaaataa cttgcacagt tgatttagca cagattctga gggaatattc atgggctcat
+    14941 attttagagg gaagacctct tattggagcc acactcccat gtatgattga gcaattcaaa
+    15001 gtgttttggc tgaaacccta cgaacaatgt ccgcagtgtt caaatgcaaa gcaaccaggt
+    15061 gggaaaccat tcgtgtcagt ggcagtcaag aaacatattg ttagtgcatg gccgaacgca
+    15121 tcccgaataa gctggactat cggggatgga atcccataca ttggatcaag gacagaagat
+    15181 aagataggac aacctgctat taaaccaaaa tgtccttccg cagccttaag agaggccatt
+    15241 gaattggcgt cccgtttaac atgggtaact caaggcagtt cgaacagtga cttgctaata
+    15301 aaaccatttt tggaagcacg agtaaattta agtgttcaag aaatacttca aatgacccct
+    15361 tcacattact caggaaatat tgttcacagg tacaacgatc aatacagtcc tcattctttc
+    15421 atggccaatc gtatgagtaa ttcagcaacg cgattgattg tttctacaaa cactttaggt
+    15481 gagttttcag gaggtggcca gtctgcacgc gacagcaata ttattttcca gaatgttata
+    15541 aattatgcag ttgcactgtt cgatattaaa tttagaaaca ctgaggctac agatatccaa
+    15601 tataatcgtg ctcaccttca tctaactaag tgttgcaccc gggaagtacc agctcagtat
+    15661 ttaacataca catctacatt ggatttagat ttaacaagat accgagaaaa cgaattgatt
+    15721 tatgacagta atcctctaaa aggaggactc aattgcaata tctcattcga taatccattt
+    15781 ttccaaggta aacggctgaa cattatagaa gatgatctta ttcgactgcc tcacttatct
+    15841 ggatgggagc tagccaagac catcatgcaa tcaattattt cagatagcaa caattcatct
+    15901 acagacccaa ttagcagtgg agaaacaaga tcattcacta cccatttctt aacttatccc
+    15961 aagataggac ttctgtacag ttttggggcc tttgtaagtt attatcttgg caatacaatt
+    16021 cttcggacta agaaattaac acttgacaat tttttatatt acttaactac tcaaattcat
+    16081 aatctaccac atcgctcatt gcgaatactt aagccaacat tcaaacatgc aagcgttatg
+    16141 tcacggttaa tgagtattga tcctcatttt tctatttaca taggcggtgc tgcaggtgac
+    16201 agaggactct cagatgcggc caggttattt ttgagaacgt ccatttcatc ttttcttaca
+    16261 tttgtaaaag aatggataat taatcgcgga acaattgtcc ctttatggat agtatatccg
+    16321 ctagagggtc aaaacccaac acctgtgaat aattttctct atcagatcgt agaactgctg
+    16381 gtgcatgatt catcaagaca acaggctttt aaaactacca taagtgatca tgtacatcct
+    16441 cacgacaatc ttgtttacac atgtaagagt acagccagca atttcttcca tgcatcattg
+    16501 gcgtactgga ggagcagaca cagaaacagc aaccgaaaat acttggcaag agactcttca
+    16561 actggatcaa gcacaaacaa cagtgatggt catattgaga gaagtcaaga acaaaccacc
+    16621 agagatccac atgatggcac tgaacggaat ctagtcctac aaatgagcca tgaaataaaa
+    16681 agaacgacaa ttccacaaga aaacacgcac cagggtccgt cgttccagtc ctttctaagt
+    16741 gactctgctt gtggtacagc aaatccaaaa ctaaatttcg atcgatcgag acacaatgtg
+    16801 aaatttcagg atcataactc ggcatccaag agggaaggtc atcaaataat ctcacaccgt
+    16861 ctagtcctac ctttctttac attatctcaa gggacacgcc aattaacgtc atccaatgag
+    16921 tcacaaaccc aagacgagat atcaaagtac ttacggcaat tgagatccgt cattgatacc
+    16981 acagtttatt gtagatttac cggtatagtc tcgtccatgc attacaaact tgatgaggtc
+    17041 ctttgggaaa tagagagttt caagtcggct gtgacgctag cagagggaga aggtgctggt
+    17101 gccttactat tgattcagaa ataccaagtt aagaccttat ttttcaacac gctagctact
+    17161 gagtccagta tagagtcaga aatagtatca ggaatgacta ctcctaggat gcttctacct
+    17221 gttatgtcaa aattccataa tgaccaaatt gagattattc ttaacaactc agcaagccaa
+    17281 ataacagaca taacaaatcc tacttggttt aaagaccaaa gagcaaggct acctaagcaa
+    17341 gtcgaggtta taaccatgga tgcagagaca acagagaata taaacagatc gaaattgtac
+    17401 gaagctgtat ataaattgat cttacaccat attgatccta gcgtattgaa agcagtggtc
+    17461 cttaaagtct ttctaagtga tactgagggt atgttatggc taaatgataa tttagccccg
+    17521 ttttttgcca ctggttattt aattaagcca ataacgtcaa gtgctagatc tagtgagtgg
+    17581 tatctttgtc tgacgaactt cttatcaact acacgtaaga tgccacacca aaaccatctc
+    17641 agttgtaaac aggtaatact tacggcattg caactgcaaa ttcaacgaag cccatactgg
+    17701 ctaagtcatt taactcagta tgctgactgt gagttacatt taagttatat ccgccttggt
+    17761 tttccatcat tagagaaagt actataccac aggtataacc tcgtcgattc aaaaagaggt
+    17821 ccactagtct ctatcactca gcacttagca catcttagag cagagattcg agaattaact
+    17881 aatgattata atcaacagcg acaaagtcgg actcaaacat atcactttat tcgtactgca
+    17941 aaaggacgaa tcacaaaact agtcaatgat tatttaaaat tctttcttat tgtgcaagca
+    18001 ttaaaacata atgggacatg gcaagctgag tttaagaaat taccagagtt gattagtgtg
+    18061 tgcaataggt tctaccatat tagagattgc aattgtgaag aacgtttctt agttcaaacc
+    18121 ttatatttac atagaatgca ggattctgaa gttaagctta tcgaaaggct gacagggctt
+    18181 ctgagtttat ttccggatgg tctctacagg tttgattgaa ttaccgtgca tagtatcctg
+    18241 atacttgcaa aggttggtta ttaacataca gattataaaa aactcataaa ttgctctcat
+    18301 acatcatatt gatctaatct caataaacaa ctatttaaat aacgaaagga gtccctatat
+    18361 tatatactat atttagcctc tctccctgcg tgataatcaa aaaattcaca atgcagcatg
+    18421 tgtgacatat tactgccgca atgaatttaa cgcaacataa taaactctgc actctttata
+    18481 attaagcttt aacgaaaggt ctgggctcat attgttattg atataataat gttgtatcaa
+    18541 tatcctgtca gatggaatag tgttttggtt gataacacaa cttcttaaaa caaaattgat
+    18601 ctttaagatt aagtttttta taattatcat tactttaatt tgtcgtttta aaaacggtga
+    18661 tagccttaat ctttgtgtaa aataagagat taggtgtaat aaccttaaca tttttgtcta
+    18721 gtaagctact atttcataca gaatgataaa attaaaagaa aaggcaggac tgtaaaatca
+    18781 gaaatacctt ctttacaata tagcagacta gataataatc ttcgtgttaa tgataattaa
+    18841 gacattgacc acgctcatca gaaggctcgc cagaataaac gttgcaaaaa ggattcctgg
+    18901 aaaaatggtc gcacacaaaa atttaaaaat aaatctattt cttctttttt gtgtgtcca
+//
+

--- a/phylogenetic/outbreak-specific/drc-2025/auspice_config.json
+++ b/phylogenetic/outbreak-specific/drc-2025/auspice_config.json
@@ -9,7 +9,7 @@
       "url": "https://pathoplexus.org"
     }
   ],
-  "build_url": "https://github.com/nextstrain/ebola",
+  "build_url": "https://github.com/nextstrain/ebola/pull/19",
   "colorings": [
     {
       "key": "gt",

--- a/phylogenetic/outbreak-specific/drc-2025/auspice_config.json
+++ b/phylogenetic/outbreak-specific/drc-2025/auspice_config.json
@@ -1,0 +1,65 @@
+{
+  "title": "Genomic epidemiology of the ongoing 2025 Ebola epidemic",
+  "maintainers": [
+    {"name": "the Nextstrain team", "url": "https://nextstrain.org/team"}
+  ],
+  "data_provenance": [
+    {
+      "name": "Pathoplexus",
+      "url": "https://pathoplexus.org"
+    }
+  ],
+  "build_url": "https://github.com/nextstrain/ebola",
+  "colorings": [
+    {
+      "key": "gt",
+      "title": "Genotype",
+      "type": "categorical"
+    },
+    {
+      "key": "num_date",
+      "title": "Date",
+      "type": "continuous"
+    },
+    {
+      "key": "dataUseTerms",
+      "title": "Data use terms",
+      "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Author",
+      "type":"categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "country",
+    "division"
+  ],
+  "metadata_columns": [
+    "strain",
+    "PPX_accession",
+    "INSDC_accession",
+    "restrictedUntil"
+  ],
+  "display_defaults": {
+    "color_by": "division",
+    "geo_resolution": "division",
+    "tip_label": "strain"
+  },
+  "filters": [
+    "country",
+    "division",
+    "author"
+  ]
+}

--- a/phylogenetic/outbreak-specific/drc-2025/description.md
+++ b/phylogenetic/outbreak-specific/drc-2025/description.md
@@ -1,0 +1,1 @@
+This is a Nextstrain analysis of the 2025 Zaire ebolavirus outbreak.

--- a/phylogenetic/outbreak-specific/drc-2025/include.txt
+++ b/phylogenetic/outbreak-specific/drc-2025/include.txt
@@ -1,0 +1,1 @@
+PP_000PHH3 # Reference / root. INSDC NC_002549. Yambuku 1976 outbreak.

--- a/phylogenetic/outbreak-specific/west-africa-2014/colors.txt
+++ b/phylogenetic/outbreak-specific/west-africa-2014/colors.txt
@@ -1,0 +1,82 @@
+## countries
+
+country	guinea	#86BB6D
+country	sierra leone	#4041C7
+country	liberia	#E4682F
+
+## divisions
+
+## replicate the countries here
+division	guinea	#86BB6D
+division	sierra leone	#4041C7
+division	liberia	#E4682F
+
+# Guinean prefectures
+division	boffa	#58A2AB
+division	boke	#56A0AE
+division	fria	#5BA7A6
+division	gaoual	#62AB9C
+division	koundara	#64AC99
+division	conakry	#60AA9F
+division	dabola	#84BA70
+division	dinguiraye	#81B973
+division	faranah	#86BB6D
+division	kissidougou	#95BD61
+division	kankan	#92BC63
+division	kerouane	#9EBE5A
+division	kouroussa	#89BB6B
+division	mandiana	#8FBC66
+division	siguiri	#8CBB68
+division	coyah	#66AE95
+division	dubreka	#5DA8A2
+division	forecariah	#68AF92
+division	kindia	#6AB18F
+division	telimele	#5AA4A8
+division	koubia	#7EB976
+division	labe	#74B582
+division	lelouma	#6FB388
+division	mali	#71B485
+division	tougue	#7CB879
+division	dalaba	#77B67F
+division	mamou	#79B77C
+division	pita	#6CB28C
+division	beyla	#A1BE58
+division	gueckedou	#98BD5E
+division	lola	#AABD52
+division	macenta	#9BBE5C
+division	nzerekore	#A4BE56
+division	yamou	#A7BE54
+
+# Sierra Leone districts
+division	kailahun	#4C90C0
+division	kenema	#447ECC
+division	kono	#4272CE
+division	bombali	#691D93
+division	kambia	#781C86
+division	koinadugu	#4041C7
+division	port loko	#691D93
+division	tonkolili	#482BB6
+division	bo	#4066CF
+division	bonthe	#4041C7
+division	moyamba	#4041C7
+division	pujehun	#4887C6
+division	western rural	#482BB6
+division	western urban	#691D93
+division	western area	#5824A4
+
+# Liberian counties
+division	nimba	#E67D33
+division	rivercess	#E68735
+division	river gee	#E29E39
+division	sinoe	#E49838
+division	bomi	#DF4528
+division	bong	#E4682F
+division	gbarpolu	#DC2D24
+division	grand cape mount	#DB2122
+division	grand bassa	#E67431
+division	grand gedeh	#E69036
+division	grand kru	#DFA53B
+division	lofa	#DE3926
+division	margibi	#E35C2C
+division	maryland	#DCAB3C
+division	montserrado	#E1512A

--- a/phylogenetic/outbreak-specific/west-africa-2014/include.txt
+++ b/phylogenetic/outbreak-specific/west-africa-2014/include.txt
@@ -1,1 +1,1 @@
-EM_076610 # flare-up index case
+PP_000LGK6 # flare-up index case. NCBI accession: KR817153. Sample name in original analysis: EM_076610

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -60,7 +60,7 @@ rule translate:
     input:
         tree = "results/{build}/tree.nwk",
         node_data = "results/{build}/nt_muts.json",
-        reference = config_path("files", "reference"),
+        reference = config_path("align", "reference"),
     output:
         node_data = "results/{build}/aa_muts.json"
     benchmark:

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -60,7 +60,7 @@ rule translate:
     input:
         tree = "results/{build}/tree.nwk",
         node_data = "results/{build}/nt_muts.json",
-        reference = lambda w: config["build_params"][w.build]["files"]["reference"],
+        reference = config_path("files", "reference"),
     output:
         node_data = "results/{build}/aa_muts.json"
     benchmark:

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -1,3 +1,19 @@
+
+# Load the default config YAML which must exist as a sister-file to the Snakefile
+if not os.path.exists(os.path.join(workflow.basedir, 'config.yaml')):
+    raise InvalidConfigError("No default config - this is the result of an error/bug in the underlying workflow.")
+configfile: os.path.join(workflow.basedir, 'config.yaml')
+
+# Merge in a config.yaml file if it exists in the current working directory
+# (most often the directory where you ran `snakemake` from, but can be changed via `--directory`)
+if os.path.exists("config.yaml"):
+    configfile: "config.yaml"
+
+# NOTE: Any extra configuration (--configfile, --config) will have been merged into the `config` structure
+# such that the precedence of "configfile: < --configfile < --config" is maintained. This happens within
+# `configfile` directives.
+
+
 def conditional(option, argument):
     """Used for config-defined arguments whose presence necessitates a command-line option
     (e.g. --foo) prepended and whose absence should result in no option/arguments in the CLI command.

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -14,6 +14,14 @@ if os.path.exists("config.yaml"):
 # `configfile` directives.
 
 
+# ------------------------------------ TEMPORARY ------------------------------------
+# We don't yet support multiple inputs, but we use the config interface which will support them
+# so check here we aren't trying to use multiple inputs
+if 'additional_inputs' in config or len(config['inputs'])!=1:
+    print("This workflow is not yet set up for multiple inputs.")
+    exit(1)
+
+
 def conditional(option, argument):
     """Used for config-defined arguments whose presence necessitates a command-line option
     (e.g. --foo) prepended and whose absence should result in no option/arguments in the CLI command.

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -57,7 +57,7 @@ rule refine:
     params:
         coalescent = lambda w: config["build_params"][w.build]["refine"]["coalescent"],
         date_inference = lambda w: config["build_params"][w.build]["refine"]["date_inference"],
-        timetree = lambda w: conditional("--timetree", config["build_params"][w.build]["refine"].get("timetree")),
+        timetree = conditional_config("--timetree", "refine", "timetree"),
         id_column = config["id_column"],
     benchmark:
         "benchmarks/{build}/refine.txt"

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -55,9 +55,12 @@ rule refine:
         tree = "results/{build}/tree.nwk",
         node_data = "results/{build}/branch_lengths.json"
     params:
-        coalescent = lambda w: config["build_params"][w.build]["refine"]["coalescent"],
-        date_inference = lambda w: config["build_params"][w.build]["refine"]["date_inference"],
+        coalescent = conditional_config("--coalescent", "refine", "coalescent"),
+        date_inference = conditional_config("--date-inference", "refine", "date_inference"),
+        confidence = conditional_config("--date-confidence", "refine", "confidence"),
         timetree = conditional_config("--timetree", "refine", "timetree"),
+        root = conditional_config("--root", "refine", "root"),
+        remove_outgroup = conditional_config("--remove-outgroup", "refine", "remove_outgroup"),
         id_column = config["id_column"],
     benchmark:
         "benchmarks/{build}/refine.txt"
@@ -72,10 +75,12 @@ rule refine:
             --alignment {input.alignment:q} \
             --metadata {input.metadata:q} \
             --metadata-id-columns {params.id_column:q} \
-            --output-tree {output.tree:q} \
-            --output-node-data {output.node_data:q} \
             {params.timetree:q} \
-            --coalescent {params.coalescent:q} \
-            --date-confidence \
-            --date-inference {params.date_inference:q}
+            {params.date_inference:q} \
+            {params.coalescent:q} \
+            {params.confidence:q} \
+            {params.root:q} \
+            {params.remove_outgroup:q} \
+            --output-tree {output.tree:q} \
+            --output-node-data {output.node_data:q}
         """

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -41,7 +41,7 @@ rule export:
         auspice_json = "auspice/ebola_{build}.json"
     params:
         id_column = config["id_column"],
-        warning = lambda w: conditional("--warning", config["build_params"][w.build].get("export", {}).get("warning")),
+        warning = conditional_config("--warning", "export", "warning"),
     benchmark:
         "benchmarks/{build}/export.txt"
     log:

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -42,6 +42,7 @@ rule export:
     params:
         id_column = config["id_column"],
         warning = conditional_config("--warning", "export", "warning"),
+        colors = conditional_config("--colors", "export", "colors"),
     benchmark:
         "benchmarks/{build}/export.txt"
     log:
@@ -59,6 +60,7 @@ rule export:
             --auspice-config {input.auspice_config:q} \
             --description {input.description:q} \
             {params.warning:q} \
+            {params.colors:q} \
             --include-root-sequence-inline \
             --output {output.auspice_json:q}
         """

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -34,9 +34,9 @@ rule export:
         traits = "results/{build}/traits.json",
         nt_muts = "results/{build}/nt_muts.json",
         aa_muts = "results/{build}/aa_muts.json",
-        lat_longs = config_path("files", "lat_longs"),
-        auspice_config = config_path("files", "auspice_config"),
-        description = config_path("files", "description"),
+        lat_longs = config_path("export", "lat_longs"),
+        auspice_config = config_path("export", "auspice_config"),
+        description = config_path("export", "description"),
     output:
         auspice_json = "auspice/ebola_{build}.json"
     params:

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -34,9 +34,9 @@ rule export:
         traits = "results/{build}/traits.json",
         nt_muts = "results/{build}/nt_muts.json",
         aa_muts = "results/{build}/aa_muts.json",
-        lat_longs = lambda w: config["build_params"][w.build]["files"]["lat_longs"],
-        auspice_config = lambda w: config["build_params"][w.build]["files"]["auspice_config"],
-        description = lambda w: config["build_params"][w.build]["files"]["description"],
+        lat_longs = config_path("files", "lat_longs"),
+        auspice_config = config_path("files", "auspice_config"),
+        description = config_path("files", "description"),
     output:
         auspice_json = "auspice/ebola_{build}.json"
     params:

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -81,7 +81,7 @@ rule align:
     """
     input:
         sequences = "results/{build}/filtered.fasta",
-        reference = config_path("files", "reference"),
+        reference = config_path("align", "reference"),
     output:
         alignment = "results/{build}/aligned.fasta"
     benchmark:

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -43,6 +43,7 @@ rule filter:
         min_length = lambda w: conditional("--min-length", config["build_params"][w.build]["filter"].get("min_length")),
         min_date = lambda w: conditional("--min-date", config["build_params"][w.build]["filter"].get("min_date")),
         max_date = lambda w: conditional("--max-date", config["build_params"][w.build]["filter"].get("max_date")),
+        exclude_ambiguous_dates_by = lambda w: conditional("--exclude-ambiguous-dates-by", config["build_params"][w.build]["filter"].get("exclude_ambiguous_dates_by")),
         exclude_where = lambda w: conditional("--exclude-where", config["build_params"][w.build]["filter"].get("exclude_where")),
         group_by = lambda w: conditional("--group-by", config["build_params"][w.build]["filter"].get("group_by")),
         subsample_max_sequences = lambda w: conditional("--subsample-max-sequences", config["build_params"][w.build]["filter"].get("subsample_max_sequences")),
@@ -61,6 +62,7 @@ rule filter:
             {params.min_length:q} \
             {params.min_date:q} \
             {params.max_date:q} \
+            {params.exclude_ambiguous_dates_by:q} \
             {params.exclude_where:q} \
             {params.group_by:q} \
             {params.subsample_max_sequences:q} \

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -40,13 +40,13 @@ rule filter:
         log = "results/{build}/filter-log.txt",
     params:
         id_column = config["id_column"],
-        min_length = lambda w: conditional("--min-length", config["build_params"][w.build]["filter"].get("min_length")),
-        min_date = lambda w: conditional("--min-date", config["build_params"][w.build]["filter"].get("min_date")),
-        max_date = lambda w: conditional("--max-date", config["build_params"][w.build]["filter"].get("max_date")),
-        exclude_ambiguous_dates_by = lambda w: conditional("--exclude-ambiguous-dates-by", config["build_params"][w.build]["filter"].get("exclude_ambiguous_dates_by")),
-        exclude_where = lambda w: conditional("--exclude-where", config["build_params"][w.build]["filter"].get("exclude_where")),
-        group_by = lambda w: conditional("--group-by", config["build_params"][w.build]["filter"].get("group_by")),
-        subsample_max_sequences = lambda w: conditional("--subsample-max-sequences", config["build_params"][w.build]["filter"].get("subsample_max_sequences")),
+        min_length = conditional_config("--min-length", "filter", "min_length"),
+        min_date = conditional_config("--min-date", "filter", "min_date"),
+        max_date = conditional_config("--max-date", "filter", "max_date"),
+        exclude_ambiguous_dates_by = conditional_config("--exclude-ambiguous-dates-by", "filter", "exclude_ambiguous_dates_by"),
+        exclude_where = conditional_config("--exclude-where", "filter", "exclude_where"),
+        group_by = conditional_config("--group-by", "filter", "group_by"),
+        subsample_max_sequences = conditional_config("--subsample-max-sequences", "filter", "subsample_max_sequences"),
     benchmark:
         "benchmarks/{build}/filter.txt"
     log:

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -32,8 +32,8 @@ rule filter:
     input:
         sequences = lambda w: path_or_url(config["inputs"][0]['sequences']),
         metadata = lambda w: path_or_url(config["inputs"][0]['metadata']),
-        exclude = lambda w: config["build_params"][w.build]["filter"]["exclude"],
-        include = lambda w: config["build_params"][w.build]["filter"]["include"],
+        exclude = config_path("filter", "exclude"),
+        include = config_path("filter", "include"),
     output:
         sequences = "results/{build}/filtered.fasta",
         metadata = "results/{build}/filtered.tsv",
@@ -81,7 +81,7 @@ rule align:
     """
     input:
         sequences = "results/{build}/filtered.fasta",
-        reference = lambda w: config["build_params"][w.build]["files"]["reference"],
+        reference = config_path("files", "reference"),
     output:
         alignment = "results/{build}/aligned.fasta"
     benchmark:

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -30,8 +30,8 @@ rule filter:
       - excluding strains in {input.exclude}
     """
     input:
-        sequences = "../../ingest/results/sequences.fasta",
-        metadata = "../../ingest/results/metadata.tsv",
+        sequences = lambda w: path_or_url(config["inputs"][0]['sequences']),
+        metadata = lambda w: path_or_url(config["inputs"][0]['metadata']),
         exclude = lambda w: config["build_params"][w.build]["filter"]["exclude"],
         include = lambda w: config["build_params"][w.build]["filter"]["include"],
     output:


### PR DESCRIPTION
## Description of proposed changes

This PR adds a dataset with data from the 2025 outbreak.

Private preview: https://nextstrain.org/groups/blab-private/ebola/drc-2025

## Checklist

- [x] Merge base PR #36
- [x] ~Decide on clock rate (presumably it can't it be inferred yet). Should talk to JT~ not inferring time tree
- [x] Decide on tree root
- [ ] Check location metadata coverage & accuracy
    - We can use a manual annotations TSV for any changes here and talk to Eddy while there are still so few actual samples to confirm things
- [ ] Merge and release https://github.com/nextstrain/augur/pull/1913
- [ ] Drop b27d1ba8336c323d58ade300782ea2d7c028907b, fbb04c3df2e8dedd1fa8109c0ad9192c9f888884, 7c60f7f6c45669295d5870d96e06103b265de322
- [ ] Checks pass
- [x] ~Update changelog~ N/A