### PR TITLE
Provision (nextclade) outbreaks in ingest

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -30,6 +30,7 @@ rule all:
 # by build-specific rules.
 include: "rules/fetch.smk"
 include: "rules/curate.smk"
+include: "rules/nextclade.smk"
 
 
 # We are pushing to standardize ingest workflows with Nextclade runs to include

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -75,6 +75,7 @@ curate:
     "INSDC_accession__url",
     "strain",
     "date",
+    "outbreak",
     "region",
     "country",
     "division",

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -1,32 +1,13 @@
-"""
-This part of the workflow handles running Nextclade on the curated metadata
-and sequences.
-
-REQUIRED INPUTS:
-
-    metadata    = data/subset_metadata.tsv
-    sequences   = results/sequences.fasta
-
-OUTPUTS:
-
-    metadata        = results/metadata.tsv
-    nextclade       = results/nextclade.tsv
-    alignment       = results/alignment.fasta
-    translations    = results/translations.zip
-
-See Nextclade docs for more details on usage, inputs, and outputs if you would
-like to customize the rules:
-https://docs.nextstrain.org/projects/nextclade/page/user/nextclade-cli.html
-"""
-DATASET_NAME = config["nextclade"]["dataset_name"]
 
 
+# NOTE: The dataset name/address is currently hardcoded here and points to the ebola branch
+# (see https://github.com/nextstrain/nextclade_data/pull/184)
+# This URL is expected to break once that PR is merged / the branch is deleted. At that point we
+# should update the invocation and use config variables accordingly.
 rule get_nextclade_dataset:
     """Download Nextclade dataset"""
     output:
-        dataset=f"data/nextclade_data/{DATASET_NAME}.zip",
-    params:
-        dataset_name=DATASET_NAME
+        dataset=f"data/ebola-zaire.zip",
     benchmark:
         "benchmarks/get_nextclade_dataset.txt"
     log:
@@ -36,18 +17,17 @@ rule get_nextclade_dataset:
         exec &> >(tee {log:q})
 
         nextclade3 dataset get \
-            --name={params.dataset_name:q} \
-            --output-zip={output.dataset:q} \
-            --verbose
+            --server https://raw.githubusercontent.com/nextstrain/nextclade_data/refs/heads/ebola/data_output/ \
+            --name nextstrain/ebola/zaire \
+            --output-zip {output.dataset:q}
         """
-
 
 rule run_nextclade:
     input:
-        dataset=f"data/nextclade_data/{DATASET_NAME}.zip",
         sequences="results/sequences.fasta",
+        dataset="data/ebola-zaire.zip",
     output:
-        nextclade="results/nextclade.tsv",
+        metadata="data/nextclade.tsv",
         alignment="results/alignment.fasta",
         translations="results/translations.zip",
     params:
@@ -65,65 +45,9 @@ rule run_nextclade:
         nextclade3 run \
             {input.sequences:q} \
             --input-dataset {input.dataset:q} \
-            --output-tsv {output.nextclade:q} \
+            --output-tsv {output.metadata:q} \
             --output-fasta {output.alignment:q} \
             --output-translations {params.translations:q}
 
         zip -rj {output.translations:q} results/translations
-        """
-
-
-rule nextclade_metadata:
-    input:
-        nextclade="results/nextclade.tsv",
-    output:
-        nextclade_metadata=temp("results/nextclade_metadata.tsv"),
-    params:
-        nextclade_id_field=config["nextclade"]["id_field"],
-        nextclade_field_map=[f"{old}={new}" for old, new in config["nextclade"]["field_map"].items()],
-        nextclade_fields=",".join(config["nextclade"]["field_map"].values()),
-    benchmark:
-        "benchmarks/nextclade_metadata.txt"
-    log:
-        "logs/nextclade_metadata.txt"
-    shell:
-        r"""
-        exec &> >(tee {log:q})
-
-        augur curate rename \
-            --metadata {input.nextclade:q} \
-            --id-column {params.nextclade_id_field:q} \
-            --field-map {params.nextclade_field_map:q} \
-            --output-metadata - \
-        | csvtk cut -t --fields {params.nextclade_fields:q} \
-        > {output.nextclade_metadata:q}
-        """
-
-
-rule join_metadata_and_nextclade:
-    input:
-        metadata="data/subset_metadata.tsv",
-        nextclade_metadata="results/nextclade_metadata.tsv",
-    output:
-        metadata="results/metadata.tsv",
-    params:
-        metadata_id_field=config["curate"]["output_id_field"],
-        nextclade_id_field=config["nextclade"]["id_field"],
-    benchmark:
-        "benchmarks/join_metadata_and_nextclade.txt"
-    log:
-        "logs/join_metadata_and_nextclade.txt"
-    shell:
-        r"""
-        exec &> >(tee {log:q})
-
-        augur merge \
-            --metadata \
-                metadata={input.metadata:q} \
-                nextclade={input.nextclade_metadata:q} \
-            --metadata-id-columns \
-                metadata={params.metadata_id_field:q} \
-                nextclade={params.nextclade_id_field:q} \
-            --output-metadata {output.metadata:q} \
-            --no-source-columns
         """


### PR DESCRIPTION
~Copies the forthcoming Nextclade dataset https://github.com/nextstrain/nextclade_data/pull/184 into the repo~ Uses a WIP nextclade dataset so that we can assign 'outbreak' in the ingested metadata TSV. Knowing the outbreak is useful for phylo workflows.

We also get alignments and translations as part of running Nextclade in ingest, however it's unclear what intermediate files we ultimately want to maintain.

@rneher I was going to cherry-pick your commits from `ran/nextclade` but took this easier route. ~Ultimately I presume we'll use `nextclade get` rather than committing the dataset into the repo?~

