### PR TITLE
ingest: Only download latest version of sequences

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -5,7 +5,7 @@
 # do not have to dig through the workflows to figure out the default values
 
 ppx_fetch:
-  seqs: https://lapis.pathoplexus.org/ebola-zaire/sample/unalignedNucleotideSequences
+  seqs: https://lapis.pathoplexus.org/ebola-zaire/sample/unalignedNucleotideSequences?versionStatus=LATEST_VERSION
   meta: https://lapis.pathoplexus.org/ebola-zaire/sample/details?dataFormat=csv&versionStatus=LATEST_VERSION
 
 # Required to fetch from Entrez


### PR DESCRIPTION
## Description of proposed changes

I noticed a large number of sequences without matching metadata and realized the workflow was downloading all versions of sequences but only the latest version of metadata. I can't find any documentation on the `versionStatus` query param, but local testing shows it also works for sequences. This reduced the runtime from 83s to 24s and reduced file size from 200M to 63M.

## Related issue(s)

Follow up to https://github.com/nextstrain/ebola/pull/25#issuecomment-3293595377

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
