### PR TITLE
CI: run on push to new default branch `main`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
   # Routinely check that we continue to work in the face of external changes.


### PR DESCRIPTION
## Description of proposed changes

The default branch for this repo was renamed from `master` to `main` as  noted in https://github.com/nextstrain/ebola/pull/14.

Unfortunately there's no variable for the default branch that can be used in  the `on.push` block, so this has to be manually maintained. We could add a  conditional for `jobs.ci` to only run on the default branch, but this would  cause the CI workflow to trigger on every push and just skip the `ci` job.  I think it's cleaner to just manually maintain the default branch name since  it's unlikely that we'll change it again.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
