### PR TITLE
Update annotations

### DIFF
--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -5,6 +5,3 @@
 # Lines starting with '#' are treated as comments
 # Any '#' after the field value are treated as comments.
 
-# Russian sample from <https://www.ncbi.nlm.nih.gov/nuccore/EU224440.2>
-# title: Genetic factors of Ebola virus virulence in guinea pigs
-PP_000LD2A	is_lab_host	True

--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -19,3 +19,5 @@ PP_000MQMS	is_lab_host	True
 PP_000MMZ5	is_lab_host	True
 PP_000N0GR	is_lab_host	True
 
+# host 'Homo sapiens; F; 65Y' in the INSDC record (KR867676)
+PP_000M5Q5	host	Homo sapiens

--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -5,3 +5,10 @@
 # Lines starting with '#' are treated as comments
 # Any '#' after the field value are treated as comments.
 
+# The following strains are missing temporal information, but are all genetically from the West-African 2013- outbreak
+# and have informative strain names. Note: Geographic info updated in annotations_geo.tsv
+# Ebola virus/H.sapiens-rec/LBR/2014/Makona-L2014
+PP_000LE29	date	2014-XX-XX
+# NML/BALB/c-lab/GIN/2014/Makona-Gueckedou-C07-rgMA
+PP_000NU8D	date	2014-XX-XX
+

--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -12,3 +12,10 @@ PP_000LE29	date	2014-XX-XX
 # NML/BALB/c-lab/GIN/2014/Makona-Gueckedou-C07-rgMA
 PP_000NU8D	date	2014-XX-XX
 
+# These 3 samples are genetically from the Kikwit 1995 outbreak but are all collected in
+# 2012 and from Macaca mulatta (rhesus macaque). Since they're sequenced by USAMRIID
+# my assumption is that they're lab experiments 
+PP_000MQMS	is_lab_host	True
+PP_000MMZ5	is_lab_host	True
+PP_000N0GR	is_lab_host	True
+

--- a/ingest/defaults/annotations_geo.tsv
+++ b/ingest/defaults/annotations_geo.tsv
@@ -77,6 +77,108 @@ PP_000MC45	country	Sierra Leone
 PP_000MC45	region	Africa
 
 
+# 1976 outbreak was entirely in Northen Zaire (DRC)
+# From WHO bulletin "Ebola haemorrhagic fever in Zaire, 1976" <https://pmc.ncbi.nlm.nih.gov/articles/PMC2395567/>
+# "Between 1 September and 24 October 1976, 318 cases of acute viral haemorrhagic fever occurred in northern Zaire." 
+# "most of the cases were recorded within a radius of 70 km of Yambuku, although a few patients sought medical attention in Bumba, Abumombazi, and the capital city of Kinshasa, where individual secondary and tertiary cases occurred."
+# These strains have no geographic information, but genetically they're from the 1976 outbreak.
+# Many don't have strain names. Where they do it's often "Mayinga" or "Yambuku-Mayinga"
+# (Mayinga was the nurse incorrectly ID'd as the index, and the virus has been called "strain Mayinga", "variant Mayinga" or "EBOV/May")
+# (Yambuku is the index village in Mongala Province)
+PP_000LAXN	region	Africa
+PP_000LAXN	country	Democratic Republic of the Congo
+PP_000LAYL	region	Africa
+PP_000LAYL	country	Democratic Republic of the Congo
+PP_000LAZJ	region	Africa
+PP_000LAZJ	country	Democratic Republic of the Congo
+PP_000LB72	region	Africa
+PP_000LB72	country	Democratic Republic of the Congo
+PP_000LCCR	region	Africa
+PP_000LCCR	country	Democratic Republic of the Congo
+PP_000LD38	region	Africa
+PP_000LD38	country	Democratic Republic of the Congo
+PP_000LD54	region	Africa
+PP_000LD54	country	Democratic Republic of the Congo
+PP_000LD62	region	Africa
+PP_000LD62	country	Democratic Republic of the Congo
+PP_000LD70	region	Africa
+PP_000LD70	country	Democratic Republic of the Congo
+PP_000LD8Y	region	Africa
+PP_000LD8Y	country	Democratic Republic of the Congo
+PP_000LD9W	region	Africa
+PP_000LD9W	country	Democratic Republic of the Congo
+PP_000LDBS	region	Africa
+PP_000LDBS	country	Democratic Republic of the Congo
+PP_000LDCQ	region	Africa
+PP_000LDCQ	country	Democratic Republic of the Congo
+PP_000LDDN	region	Africa
+PP_000LDDN	country	Democratic Republic of the Congo
+PP_000LDP1	region	Africa
+PP_000LDP1	country	Democratic Republic of the Congo
+PP_000LDTT	region	Africa
+PP_000LDTT	country	Democratic Republic of the Congo
+PP_000ME35	region	Africa
+PP_000ME35	country	Democratic Republic of the Congo
+PP_000ME43	region	Africa
+PP_000ME43	country	Democratic Republic of the Congo
+PP_000ME51	region	Africa
+PP_000ME51	country	Democratic Republic of the Congo
+PP_000ME6Z	region	Africa
+PP_000ME6Z	country	Democratic Republic of the Congo
+PP_000ME7X	region	Africa
+PP_000ME7X	country	Democratic Republic of the Congo
+PP_000ME8V	region	Africa
+PP_000ME8V	country	Democratic Republic of the Congo
+PP_000LERW	region	Africa
+PP_000LERW	country	Democratic Republic of the Congo
+PP_000NF7U	region	Africa
+PP_000NF7U	country	Democratic Republic of the Congo
+PP_000NJBH	region	Africa
+PP_000NJBH	country	Democratic Republic of the Congo
+PP_000PGZ6	region	Africa
+PP_000PGZ6	country	Democratic Republic of the Congo
+PP_000PHH3	region	Africa
+PP_000PHH3	country	Democratic Republic of the Congo
+PP_000PHJ1	region	Africa
+PP_000PHJ1	country	Democratic Republic of the Congo
+PP_000PHSK	region	Africa
+PP_000PHSK	country	Democratic Republic of the Congo
+PP_000PHUF	region	Africa
+PP_000PHUF	country	Democratic Republic of the Congo
+PP_000PHVD	region	Africa
+PP_000PHVD	country	Democratic Republic of the Congo
+PP_000PHWB	region	Africa
+PP_000PHWB	country	Democratic Republic of the Congo
+PP_000PJ3X	region	Africa
+PP_000PJ3X	country	Democratic Republic of the Congo
+PP_000PJ4V	region	Africa
+PP_000PJ4V	country	Democratic Republic of the Congo
+PP_000PJ5T	region	Africa
+PP_000PJ5T	country	Democratic Republic of the Congo
+PP_000PJ6R	region	Africa
+PP_000PJ6R	country	Democratic Republic of the Congo
+PP_000PJ7P	region	Africa
+PP_000PJ7P	country	Democratic Republic of the Congo
+
+# These strains are missing geographic info, but are genetically from the 1995 Kikwit outbreak
+# I'm unsure whether all cases were confined to Kikwit, <https://pubmed.ncbi.nlm.nih.gov/9988168/> may have more information
+PP_000LB80	region	Africa
+PP_000LB80	country	Democratic Republic of the Congo
+PP_000MBZF	region	Africa
+PP_000MBZF	country	Democratic Republic of the Congo
+PP_000MC0D	region	Africa
+PP_000MC0D	country	Democratic Republic of the Congo
+
+# The following strains are missing all geographic information, but are all genetically from the West-African 2013- outbreak
+# and have informative strain names. Note: The dates are are all XXXX-XX-XX and have been updated in annotations.tsv
+# Ebola virus/H.sapiens-rec/LBR/2014/Makona-L2014
+PP_000LE29	region	Africa
+PP_000LE29	country	Liberia
+# NML/BALB/c-lab/GIN/2014/Makona-Gueckedou-C07-rgMA
+PP_000NU8D	region	Africa
+PP_000NU8D	country	Guinea
+
+
 # -------- Temporary -----------
 # Add outbreak calls for Ebov-2014 (Boende 2014) which isn't being called by the latest nextclade dataset
 # This should be removed once the Nextclade dataset has been updated.

--- a/ingest/rules/fetch.smk
+++ b/ingest/rules/fetch.smk
@@ -122,6 +122,7 @@ rule parse_genbank_to_ndjson:
                 accession: .record.accessions[0],
                 strain:    .record.strain[0],
                 isolate:   .record.isolate[0],
+                host:      .record.host[0],
                 title:     .record.references[0].title,
                 note:      .record.note[0],
               }}

--- a/ingest/rules/fetch.smk
+++ b/ingest/rules/fetch.smk
@@ -122,6 +122,8 @@ rule parse_genbank_to_ndjson:
                 accession: .record.accessions[0],
                 strain:    .record.strain[0],
                 isolate:   .record.isolate[0],
+                title:     .record.references[0].title,
+                note:      .record.note[0],
               }}
             ' > {output.ndjson:q}
         """

--- a/ingest/scripts/lab_hosts.py
+++ b/ingest/scripts/lab_hosts.py
@@ -1,0 +1,147 @@
+#! /usr/bin/env python3
+
+"""
+Labels strains as `is_lab_host=True` based on certain metadata and a
+hardcoded list of checks in this script.
+
+For ad-hoc labels we can use the `annotations.tsv`
+"""
+
+import argparse
+import pandas as pd
+from collections import defaultdict
+
+# Set of NCBI titles via `jq -r '.title' data/ncbi_entrez.ndjson | sort -u`
+LAB_TITLES = set([
+    'A replication inhibitor of Filoviridae virus',
+    'An upstream open reading frame modulates ebola virus polymerase translation and virus replication',
+    'Fluorescent and bioluminescent reporter mouse-adapted Ebola viruses maintain pathogenicity and can be visualized in vivo',
+    "Characterization of the L gene and 5' trailer region of Ebola virus",
+    'Chimeric filovirus glycoprotein',
+    'Chimeric Filoviruses for Identification and Characterization of Monoclonal Antibodies',
+    'CHIMERIC VSV VIRUS COMPOSITIONS AND METHODS OF USE THEREOF FOR TREATMENT OF CANCER',
+    'COMPOSITIONS AND METHODS FOR DETECTING AN RNA VIRUS',
+    'CRISPR SYSTEM BASED DROPLET DIAGNOSTIC SYSTEMS AND METHODS',
+    'Development of a reverse genetics system to generate a recombinant Ebola virus Makona expressing a green fluorescent protein',
+    'Diagnostic reverse-transcription polymerase chain reaction kit for filoviruses based on the strain collections of all European biosafety level 4 laboratories',
+    'DNA vaccines expressing either the GP or NP genes of Ebola virus protect mice from lethal challenge',
+    'Ebola virus seed stock sequencing',
+    'Ebolavirus chimerization for development of a mouse model for screening of bundibugyo-specific antibodies in vivo',
+    'Evaluation of Signature Erosion in Ebola Virus Due to Genomic Drift and Its Impact on the Performance of Diagnostic Assays',
+    'Evidence for replication absent genetic diversification and high concentration of Ebola virus in semen of a patient recovering from severe disease',
+    'FDA dAtabase for Regulatory Grade micrObial Sequences (FDA-ARGOS): Supporting development and validation of Infectious Disease Dx tests',
+    'Fruit bats as reservoirs of Ebola virus',
+    'Generation and Characterization of a Mouse-Adapted Makona Variant of Ebola Virus',
+    'GP mRNA of Ebola virus is edited by the Ebola virus polymerase and by T7 and vaccinia virus polymerases',
+    'HUMAN EBOLA VIRUS SPECIES AND COMPOSITIONS AND METHODS THEREOF',
+    'Implementation of a non-human primate model of Ebola disease: Infection of Mauritian cynomolgus macaques and analysis of virus populations',
+    "Informing the Historical Record of Experimental Nonhuman Primate Infections with Ebola Virus: Genomic Characterization of USAMRIID Ebola Virus/H.sapiens-tc/COD/1995/Kikwit-9510621 Challenge Stock 'R4368' and Its Replacement 'R4415'",
+    'METHODS AND DEVICES FOR REAL-TIME DIAGNOSTIC TESTING (RDT) FOR EBOLA AND OTHER INFECTIOUS DISEASES',
+    'METHODS OF DETECTING EBOLA',
+    'Monoclonal antibodies and vaccines against epitopes on the ebola virus glycoprotein',
+    'Mouse adapted variant of Ebola virus subtype Zaire strain Mayinga complete genome',
+    'Genetic factors of Ebola virus virulence in guinea pigs',
+    'Mutations In Ebola Virus-Makona Genome Do Not Seem To Alter Pathogenicity In Animal Models',
+    'PRIMER SET FOR DETECTION OF ZAIRE EBOLA VIRUS, ASSAY KIT, AND AMPLIFICATION METHOD',
+    'Primer set, Assay kit and Detecting method for Zaire Ebolavirus',
+    'Rapid detection of all known ebolavirus species by reverse transcription-loop-mediated isothermal amplification (RT-LAMP)',
+    'RAPID VACCINE PLATFORM',
+    'Recombinant Ebola virus nucleoprotein and glycoprotein (Gabon 94 strain) provide new tools for the detection of human infections',
+    'Screen for inhibitors of filovirus and uses therefor',
+    'The nucleoprotein gene of Ebola virus: cloning, sequencing, and in vitro expression',
+    'The virion glycoproteins of Ebola viruses are encoded in two reading frames and are expressed through transcriptional editing',
+    'The VP35 and VP40 proteins of filoviruses. Homology between Marburg and Ebola viruses',
+    'Therapeutic efficacy of the small molecule GS-5734 against Ebola virus in rhesus monkeys',
+    'Uncovering the Etiology of Fevers of Unknown Origin: a laboratory-based observational study in patients with suspected Ebola, Guinea, 2014',
+    'Recombinant biologically contained filovirus',
+    'Preliminary Evaluation of the Effect of Investigational Ebola Virus Disease Treatments on Viral Genome Sequences',
+    'Effect of Experimental Treatment on Imported Ebola Genome Sequences',
+])
+
+NOTES = set([
+    'harvest date: 01-May-2015; passaged 3x in cell culture (parent stock: SAMN05859699)',
+    'harvest date: 06-MAR-2015; passaged 3x in cell culture following isolation (parent stock: SAMN05755726)',
+    'harvest date: 07-May-2015; passaged 3x in cell culture (parent stock: SAMN04488486)',
+    'harvest date: 09-Jun-2015; passaged 3x in cell culture (parent stock: SAMN04488486)',
+    'harvest date: 15-Apr-2015; passaged 3x in cell culture (parent stock: SAMN04488486)',
+    'harvest date: 15-Jul-2015; passaged 2x in cell culture',
+    'harvest date: 16-Jan-2015; passaged 2x in cell culture',
+    'harvest date: 16-Oct-2014; passaged 2x in cell culture',
+    'harvest date: 17-Jul-2015; passaged 4x in cell culture',
+    'harvest date: 21-Jan-2016; passaged 4x (parent stock: SAMN05859700)',
+    'harvest date: 21-Nov-2014; passaged 3x in cell culture (parent stock: SAMN04488486)',
+    'harvest date: 25-Oct-2014; passaged 3x in cell culture (parent stock: SAMN04488486)',
+    'harvest date: 28-Aug-2014; passaged 5x in cell culture',
+    'harvest date: 30-Dec-2014; passaged 2x in cell culture following isolation',
+    'harvest date: Aug-2015; passaged 3x in cell culture (parent stock: SAMN05860094)',
+    'chimeric molecule between Ebola virus Glycoprotein 1 and Ebola virus Glycoprotein 2',
+    'mouse-adapted in Balb/c mice',
+    'mouse-adapted, recombinant Ebola virus',
+    'mouse-adapted, recombinant Ebola virus, expressing fused ZsG and nLuc',
+    'mouse-adapted, recombinant Ebola virus, expressing nLuc',
+    'mouse-adapted, recombinant Ebola virus, expressing nLuc and ZsG',
+    'mouse-adapted, recombinant Ebola virus, expressing ZsG',
+    'mouse-adapted; harvest date: 19-Jun-2015; passaged 2x in cell culture following isolation and plaque-picking',
+    'mouse-adapted; harvest date: 19-Jun-2015; passaged 3x in cell culture following isolation and plaque-picking (parent stock: SAMN05859701)',
+    'passage details: 5 passages on VeroE6',
+    'passage details: P0',
+    'passage details: P2',
+    'passage details: passaged in VERO E-6 cells',
+    'passage details: passaged in Vero E-6 cells and havested on 15-Jan-2015',
+    'passage details: passaged using clone R4414 as a seed',
+    'passage details: propagated in Vero E6 cells and harvested on 12-Aug-2014 after 13 days in culture',
+    'passage details: Total 2 passages CDC (Vero E6 (1)/ PHE Porton Vero E6 (1))',
+    'passage details: Total 3 passages CDC (Vero E6 (1)/ PHE Porton Vero E6 (2))',
+    'passaged twice in cell culture',
+    'recombinant virus derived from Zaire ebolavirus isolate Ebola virus/H.sapiens-wt/LBR/2014/Makona-201403007 (KP178538)',
+    'recombinant virus derived from Zaire ebolavirus isolate Ebola virus/H.sapiens-wt/LBR/2014/Makona-201403007 (KP178538); sequence coding for ZsGreen-P2A-VP40 fusion is inserted in VP40 gene',
+    'recombinant virus obtained by reverse genetics',
+    'recombinant virus obtained by reverse genetics; contains marker gene fusion',
+    'recombinant virus; sequence based on INSDC accession AF086833.2; four silent mutations (genetic markers) compared to AF086833.2: c2149g, a11043g, c13194g, c15639g',
+    'USAMRIID_ID#16502; Vero E6 passage #3',
+    'mAb114-post-treatment',
+])
+
+
+excluded = {
+    "title": defaultdict(list),
+    "note": defaultdict(list),
+}
+
+def is_lab_host(row):
+    """
+    Apply strain preference hierarchy for rows that have a match.
+    Preference: ncbi.strain > ncbi.isolate > ppx.strain
+    """
+    if row['is_lab_host'] is True:
+        return True
+    if row['title'] in LAB_TITLES:
+        excluded['title'][row['title']].append(row)
+        return True
+    if row['note'] in NOTES:
+        excluded['note'][row['note']].append(row)
+        return True
+    return ''
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metadata", required=True, help="Input metadata TSV file")
+    parser.add_argument("--output", required=True, help="Output metadata TSV file")
+    args = parser.parse_args()
+
+    metadata = pd.read_csv(args.metadata, sep='\t')
+
+    n = 0
+    metadata['is_lab_host'] = metadata.apply(is_lab_host, axis=1)
+    for reason in excluded.keys():
+        for value,rows in excluded[reason].items():
+            print(f"{len(rows)} strains set as 'is_lab_host=True' due to \"{reason}\"=\"{value}\"")
+            for row in rows:
+                print(f"\t{row['accession']} ({row['strain']})")
+                n+=1
+    print('-'*80 + f"\nMarked {n} strains as lab host due to metadata matches\n" + '-'*80)
+
+    metadata.to_csv(args.output, sep='\t', index=False)
+
+
+

--- a/ingest/scripts/spike_in_ncbi_data.py
+++ b/ingest/scripts/spike_in_ncbi_data.py
@@ -28,6 +28,19 @@ def update_strain(row):
     else:
         return row['strain']
 
+
+def update_host(row):
+    """
+    Apply host using NCBI data if there's no PPX information    
+    (As of 2025-09-22 no host information is in PPX)
+    """
+    if pd.notna(row['host']):
+        return row['host']
+    if pd.notna(row['host_ncbi']) and row['host_ncbi'].strip():
+        return row['host_ncbi'].strip()
+    return ''
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--metadata-ppx", required=True, help="PPX metadata TSV file")
@@ -48,6 +61,9 @@ if __name__ == "__main__":
 
     # Apply strain preference hierarchy for rows that have a match
     merged['strain'] = merged.apply(update_strain, axis=1)
+
+    # Apply host preference hierarchy for rows that have a match
+    merged['host'] = merged.apply(update_host, axis=1)
 
     # Remove all ncbi columns from the merge unless they're in `--add-fields`, in which case keep them!
     if len(args.add_fields):

--- a/phylogenetic/all-outbreaks/Snakefile
+++ b/phylogenetic/all-outbreaks/Snakefile
@@ -16,7 +16,7 @@ rule filter:
     input:
         alignment = lambda w: path_or_url(inputs['alignment']),
         metadata = lambda w: path_or_url(inputs['metadata']),
-        exclude = "defaults/exclude.txt",
+        exclude = "all-outbreaks/exclude.txt",
         include = "all-outbreaks/include.txt",
     output:
         sequences = "results/all-outbreaks/filtered.fasta",

--- a/phylogenetic/all-outbreaks/auspice-config.json
+++ b/phylogenetic/all-outbreaks/auspice-config.json
@@ -55,6 +55,11 @@
       "type": "categorical"
     },
     {
+      "key": "date_submitted",
+      "title": "Date Submitted (PPX)",
+      "type": "temporal"
+    },
+    {
       "key": "dataUseTerms",
       "title": "Data use terms",
       "type": "categorical"

--- a/phylogenetic/all-outbreaks/auspice-config.json
+++ b/phylogenetic/all-outbreaks/auspice-config.json
@@ -50,6 +50,11 @@
       ] 
     },
     {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
       "key": "dataUseTerms",
       "title": "Data use terms",
       "type": "categorical"


### PR DESCRIPTION
Improves the ingested metadata in a number of ways. I'm going to merge & update the live dataset, but hopefully we can discuss some aspects here post-merge (and make changes in future PRs as needed!)

## Lab host

Uses metadata matching to label around 200 strains as `is_lab_host=True` based on the INSDC title / note. These are logged in `logs/lab_hosts.txt`. Here's a sample of the output:

```console
$ head logs/lab_hosts.txt 
1 strains set as 'is_lab_host=True' due to "title"="DNA vaccines expressing either the GP or NP genes of Ebola virus protect mice from lethal challenge"
        PP_003V5QL (Democratic_Republic_of_the_Congo/PP_003V5QL.1/2022-05-04)
2 strains set as 'is_lab_host=True' due to "title"="Characterization of the L gene and 5' trailer region of Ebola virus"
        PP_003V5QL (Democratic_Republic_of_the_Congo/PP_003V5QL.1/2022-05-04)
        PP_003V5QL (Democratic_Republic_of_the_Congo/PP_003V5QL.1/2022-05-04)
1 strains set as 'is_lab_host=True' due to "title"="Mouse adapted variant of Ebola virus subtype Zaire strain Mayinga complete genome"
        PP_003V5QL (Democratic_Republic_of_the_Congo/PP_003V5QL.1/2022-05-04)
1 strains set as 'is_lab_host=True' due to "title"="Monoclonal antibodies and vaccines against epitopes on the ebola virus glycoprotein"
        PP_003V5QL (Democratic_Republic_of_the_Congo/PP_003V5QL.1/2022-05-04)
```

This approach is probably too conservative (as in, we may be excluding legitimate sequenced cases). An alternative approach would be to encode this information in `annotations.tsv` and then allow manual curation in the future. cc @joverlee521 @victorlin 

I also added some manual annotations to set lab host as well.

## Host

Many of the excluded strains had a non-huma INSDC "host", so I extracted this field and added it to the all-outbreaks build. Currently all samples which pass our filters are either human or missing/undefined, however including it in the build serves as a good QC check.

## Geographic additions

I added country annotations by manually going through metadata. This is done for all strains which are not lab host and are over 18kb seq length.
