### PR TITLE
fix(nextclade): align dataset metadata with schema

### DIFF
--- a/nextclade/dataset_files/sudan/pathogen.json
+++ b/nextclade/dataset_files/sudan/pathogen.json
@@ -11,15 +11,13 @@
   "attributes": {
     "name": "Ebolavirus Zaire",
     "reference accession": "NC_002549.1",
-    "reference name": "COD/1976/Yambuku-Mayinga"
+    "reference name": "COD/1976/Yambuku-Mayinga",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "treeJson": "tree.json",
     "changelog": "CHANGELOG.md",
@@ -29,12 +27,10 @@
     "readme": "README.md",
     "reference": "reference.fasta"
   },
-  "official": true,
   "qc": {
     "frameShifts": {
       "enabled": true,
-      "ignoredFrameShifts": [
-      ],
+      "ignoredFrameShifts": [],
       "scoreWeight": 50
     },
     "missingData": {
@@ -62,8 +58,7 @@
     },
     "stopCodons": {
       "enabled": true,
-      "ignoredStopCodons": [
-      ],
+      "ignoredStopCodons": [],
       "scoreWeight": 50
     }
   },

--- a/nextclade/dataset_files/zaire/pathogen.json
+++ b/nextclade/dataset_files/zaire/pathogen.json
@@ -11,15 +11,13 @@
   "attributes": {
     "name": "Ebola virus",
     "reference accession": "NC_002549.1",
-    "reference name": "COD/1976/Yambuku-Mayinga"
+    "reference name": "COD/1976/Yambuku-Mayinga",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "treeJson": "tree.json",
     "changelog": "CHANGELOG.md",
@@ -29,12 +27,10 @@
     "readme": "README.md",
     "reference": "reference.fasta"
   },
-  "official": true,
   "qc": {
     "frameShifts": {
       "enabled": true,
-      "ignoredFrameShifts": [
-      ],
+      "ignoredFrameShifts": [],
       "scoreWeight": 50
     },
     "missingData": {
@@ -62,8 +58,7 @@
     },
     "stopCodons": {
       "enabled": true,
-      "ignoredStopCodons": [
-      ],
+      "ignoredStopCodons": [],
       "scoreWeight": 50
     }
   },


### PR DESCRIPTION
Move `experimental` from top level to `attributes` and remove obsolete `deprecated`, `enabled`, and `official` fields from both Nextclade dataset configs (zaire, sudan).

These top-level metadata fields are not defined in the pathogen.json schema and are silently ignored by Nextclade. The `experimental` flag belongs under `attributes`, where Nextclade reads it. The `enabled` and `official` fields are not valid dataset-level properties.

| Field | Action | Datasets |
|---|---|---|
| `deprecated: false` | Remove (default is false) | zaire, sudan |
| `experimental: true` | Move to `attributes.experimental` | zaire, sudan |
| `enabled: true` | Remove (not in schema) | zaire, sudan |
| `official: true` | Remove (not in schema) | zaire, sudan |

- [x] Move `experimental` into `attributes` in both dataset configs
- [x] Remove `deprecated`, `enabled`, `official` from both dataset configs

> :warning: The existing datasets in `nextclade_data` are already patched in nextstrain/nextclade_data#438, so no immediate resubmission is needed. But without this upstream fix, the misplaced fields will reappear on the next dataset submission from this workflow.

> :information_source: See [pathogen.json schema](https://github.com/nextstrain/nextclade/blob/master/packages/nextclade-schemas/input-pathogen-json.schema.json) for the `PathogenJson` and `PathogenAttributes` definitions.

1. Related to: nextstrain/nextclade_data#438