### PR TITLE
[ingest] EBOV, BDBV, SUDV

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -8,6 +8,8 @@ workdir: workflow.current_basedir
 # Use default configuration values. Override with Snakemake's --configfile/--config options.
 configfile: "defaults/config.yaml"
 
+SPECIES = ['ebov', 'bdbv', 'sudv']
+
 # This is the default rule that Snakemake will run when there are no specified targets.
 # The default output of the ingest workflow is usually the curated metadata and sequences.
 # Nextstrain-maintained ingest workflows will produce metadata files with the
@@ -17,10 +19,10 @@ configfile: "defaults/config.yaml"
 # TODO: Add link to centralized docs on standard Nextstrain metadata fields
 rule all:
     input:
-        "results/sequences.fasta",
-        "results/metadata.tsv",
-        "results/sequences_open.fasta",
-        "results/metadata_open.tsv",
+        expand("results/{species}/sequences.fasta", species=SPECIES),
+        expand("results/{species}/metadata.tsv", species=SPECIES),
+        expand("results/{species}/sequences_open.fasta", species=SPECIES),
+        expand("results/{species}/metadata_open.tsv", species=SPECIES),
 
 
 # Note that only PATHOGEN-level customizations should be added to these
@@ -32,33 +34,6 @@ include: "rules/fetch.smk"
 include: "rules/curate.smk"
 include: "rules/nextclade.smk"
 
-
-# We are pushing to standardize ingest workflows with Nextclade runs to include
-# Nextclade outputs in our publicly hosted data. However, if a Nextclade dataset
-# does not already exist, creating one requires curated data as input, so we are making
-# Nextclade steps optional here.
-#
-# If Nextclade config values are included, the nextclade rules will create the
-# final metadata TSV by joining the Nextclade output with the metadata.
-# If Nextclade configs are not included, we rename the subset metadata TSV
-# to the final metadata TSV.
-# To run nextclade.smk rules, include the `defaults/nextclade_config.yaml`
-# config file with `nextstrain build ingest --configfile defaults/nextclade_config.yaml`.
-if "nextclade" in config:
-
-    include: "rules/nextclade.smk"
-
-else:
-
-    rule create_final_metadata:
-        input:
-            metadata="data/subset_metadata.tsv"
-        output:
-            metadata="results/metadata.tsv"
-        shell:
-            """
-            mv {input.metadata} {output.metadata}
-            """
 
 # Allow users to import custom rules provided via the config.
 # This allows users to run custom rules that can extend or override the workflow.

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -5,8 +5,16 @@
 # do not have to dig through the workflows to figure out the default values
 
 ppx_fetch:
-  seqs: https://lapis.pathoplexus.org/ebola-zaire/sample/unalignedNucleotideSequences?versionStatus=LATEST_VERSION
-  meta: https://lapis.pathoplexus.org/ebola-zaire/sample/details?dataFormat=csv&versionStatus=LATEST_VERSION
+  ebov: # zaire
+    seqs: https://lapis.pathoplexus.org/ebola-zaire/sample/unalignedNucleotideSequences?versionStatus=LATEST_VERSION
+    meta: https://lapis.pathoplexus.org/ebola-zaire/sample/details?dataFormat=csv&versionStatus=LATEST_VERSION
+  bdbv:
+    seqs: https://lapis.pathoplexus.org/ebola-bdbv/sample/unalignedNucleotideSequences?versionStatus=LATEST_VERSION
+    meta: https://lapis.pathoplexus.org/ebola-bdbv/sample/details?dataFormat=csv&versionStatus=LATEST_VERSION
+  sudv:
+    seqs: https://lapis.pathoplexus.org/ebola-sudan/sample/unalignedNucleotideSequences?versionStatus=LATEST_VERSION
+    meta: https://lapis.pathoplexus.org/ebola-sudan/sample/details?dataFormat=csv&versionStatus=LATEST_VERSION
+
 
 # Required to fetch from Entrez
 entrez_search_term: "txid186538[Primary Organism]"
@@ -75,7 +83,7 @@ curate:
     "INSDC_accession__url",
     "strain",
     "date",
-    "outbreak",
+    "outbreak", # this is for EBOV datasets only as it requires a nextclade dataset
     "region",
     "country",
     "division",

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -1,16 +1,5 @@
 """
 This part of the workflow handles the curation of data from Pathoplexus
-
-REQUIRED INPUTS:
-
-    data/sequences.ndjson
-    data/ncbi_entrez.ndjson
-
-OUTPUTS:
-
-    metadata    = data/subset_metadata.tsv
-    sequences   = results/sequences.fasta
-
 """
 
 
@@ -32,11 +21,11 @@ def format_field_map(field_map: dict[str, str]) -> list[str]:
 # separate files: a metadata TSV and a sequences FASTA.
 rule curate_ppx:
     input:
-        sequences_ndjson="data/sequences.ndjson",
+        sequences_ndjson="data/{species}/sequences.ndjson",
         annotations=config["curate"]["annotations"],
     output:
-        metadata="data/metadata_ppx.tsv",
-        sequences="results/sequences.fasta",
+        metadata="data/{species}/metadata_ppx.tsv",
+        sequences="results/{species}/sequences.fasta",
     params:
         field_map=format_field_map(config["curate"]["field_map"]),
         date_fields=config["curate"]["date_fields"],
@@ -51,9 +40,9 @@ rule curate_ppx:
         id_field=config["curate"]["output_id_field"],
         sequence_field=config["curate"]["output_sequence_field"],
     benchmark:
-        "benchmarks/curate_ppx.txt"
+        "benchmarks/{species}/curate_ppx.txt"
     log:
-        "logs/curate_ppx.txt"
+        "logs/{species}/curate_ppx.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -84,13 +73,15 @@ rule curate_ppx:
 
 rule curate_ncbi_entrez:
     input:
-        metadata_ndjson="data/ncbi_entrez.ndjson",
+        metadata_ndjson="data/{species}/ncbi_entrez.ndjson",
     output:
-        metadata="data/metadata_ncbi_entrez.tsv",
+        metadata="data/{species}/metadata_ncbi_entrez.tsv",
     benchmark:
-        "benchmarks/curate_ncbi_entrez.txt"
+        "benchmarks/{species}/curate_ncbi_entrez.txt"
     log:
-        "logs/curate_ncbi_entrez.txt"
+        "logs/{species}/curate_ncbi_entrez.txt"
+    wildcard_constraints:
+        species='ebov'
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -104,16 +95,18 @@ rule curate_ncbi_entrez:
 # insdcAccessionBase.
 rule spike_in_ncbi_data:
     input:
-        metadata_ppx="data/metadata_ppx.tsv",
-        metadata_ncbi_entrez="data/metadata_ncbi_entrez.tsv",
+        metadata_ppx="data/{species}/metadata_ppx.tsv",
+        metadata_ncbi_entrez="data/{species}/metadata_ncbi_entrez.tsv",
     output:
-        metadata="data/metadata_merged_ncbi.tsv",
+        metadata="data/{species}/metadata_ppx-ncbi.tsv",
     params:
         fields=["title", "note"]
     benchmark:
-        "benchmarks/spike_in_ncbi_data.txt"
+        "benchmarks/{species}/spike_in_ncbi_data.txt"
     log:
-        "logs/spike_in_ncbi_data.txt"
+        "logs/{species}/spike_in_ncbi_data.txt"
+    wildcard_constraints:
+        species='ebov'
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -128,14 +121,16 @@ rule spike_in_ncbi_data:
 
 rule spike_in_inrb_metadata:
     input:
-        metadata="data/metadata_merged_ncbi.tsv",
-        nord_kivu_metadata="data/inrb-drc-nord-kivu-metadata.tsv",
+        metadata="data/{species}/metadata_ppx-ncbi.tsv",
+        nord_kivu_metadata="data/{species}/inrb-drc-nord-kivu-metadata.tsv",
     output:
-        metadata="data/metadata_merged_inrb.tsv",
+        metadata="data/{species}/metadata_ppx-ncbi-inrb.tsv",
     benchmark:
-        "benchmarks/spike_in_inrb_metadata.txt"
+        "benchmarks/{species}/spike_in_inrb_metadata.txt"
     log:
-        "logs/spike_in_inrb_metadata.txt"
+        "logs/{species}/spike_in_inrb_metadata.txt"
+    wildcard_constraints:
+        species='ebov'
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -148,14 +143,16 @@ rule spike_in_inrb_metadata:
 
 rule spike_in_fauna_metadata:
     input:
-        metadata="data/metadata_merged_inrb.tsv",
+        metadata="data/{species}/metadata_ppx-ncbi-inrb.tsv",
         fauna_metadata="defaults/west-africa-2013-metadata.tsv",
     output:
-        metadata="data/metadata_merged_fauna.tsv",
+        metadata="data/{species}/metadata_ppx-ncbi-inrb-fauna.tsv",
     benchmark:
-        "benchmarks/spike_in_fauna_metadata.txt"
+        "benchmarks/{species}/spike_in_fauna_metadata.txt"
     log:
-        "logs/spike_in_fauna_metadata.txt"
+        "logs/{species}/spike_in_fauna_metadata.txt"
+    wildcard_constraints:
+        species='ebov'
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -166,46 +163,23 @@ rule spike_in_fauna_metadata:
             --output {output.metadata:q}
         """
 
-rule add_nextclade_clades:
-    """
-    Normally we use nextclade for a varity of metadata fields, but here we only add
-    the 'clade' column, renaming it to 'outbreak'
-    """
-    input:
-        metadata="data/metadata_merged_fauna.tsv",
-        nextclade="data/nextclade.tsv",
-    output:
-        nextclade_subset=temp("data/nextclade_subset.tsv"),
-        metadata="data/metadata_merged_outbreak.tsv",
-    benchmark:
-        "benchmarks/add_nextclade_clades.txt"
-    log:
-        "logs/add_nextclade_clades.txt"
-    shell:
-        r"""
-        exec &> >(tee {log:q})
 
-        cat {input.nextclade} \
-            | csvtk -t cut -f seqName,clade \
-            | csvtk -t rename -f seqName,clade -n accession,outbreak \
-            > {output.nextclade_subset:q}
+def get_base_metadata(wildcards):
+    # Zaire has a bunch of extra sources spiked in
+    if wildcards.species == 'ebov':
+        return "data/ebov/metadata_ppx-ncbi-inrb-fauna.tsv"
+    return f"data/{wildcards.species}/metadata_ppx.tsv"
 
-        augur merge \
-            --metadata metadata={input.metadata:q} nextclade={output.nextclade_subset:q} \
-            --metadata-id-columns accession \
-            --output-metadata {output.metadata:q} \
-            --no-source-columns
-        """
 
 rule extract_date_from_strain:
     input:
-        metadata="data/metadata_merged_outbreak.tsv",
+        metadata=get_base_metadata,
     output:
-        metadata="data/metadata_date_improvements.tsv",
+        metadata="data/{species}/metadata_date-improvements.tsv",
     benchmark:
-        "benchmarks/extract_date_from_strain.txt"
+        "benchmarks/{species}/extract_date_from_strain.txt"
     log:
-        "logs/extract_date_from_strain.txt"
+        "logs/{species}/extract_date_from_strain.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -220,13 +194,13 @@ rule extract_date_from_strain:
 rule lab_hosts:
     """Mark strains as is_lab_host=True via metadata matching"""
     input:
-        metadata = "data/metadata_date_improvements.tsv",
+        metadata = "data/{species}/metadata_date-improvements.tsv",
     output:
-        metadata="data/metadata_lab_host_improvements.tsv",
+        metadata="data/{species}/metadata_lab-host-improvements.tsv",
     benchmark:
-        "benchmarks/lab_hosts.txt"
+        "benchmarks/{species}/lab_hosts.txt"
     log:
-        "logs/lab_hosts.txt"
+        "logs/{species}/lab_hosts.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -236,20 +210,21 @@ rule lab_hosts:
             --output {output.metadata:q}
         """
 
+
 rule curate_geography:
     input:
-        metadata="data/metadata_lab_host_improvements.tsv",
+        metadata="data/{species}/metadata_lab-host-improvements.tsv",
         geolocation_rules=config["curate_geography"]["local_geolocation_rules"],
         annotations=config["curate_geography"]["annotations"],
     output:
-        metadata="data/metadata_geo_improvements.tsv",
+        metadata="data/{species}/metadata_geo-improvements.tsv",
     params:
         id_column=config["curate_geography"]["id_column"],
         annotations_id=config["curate_geography"]["annotations_id"],
     benchmark:
-        "benchmarks/curate_geography.txt"
+        "benchmarks/{species}/curate_geography.txt"
     log:
-        "logs/curate_geography.txt"
+        "logs/{species}/curate_geography.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -271,18 +246,18 @@ rule add_accession_urls:
     - url: URL linking to the NCBI GenBank record ('https://www.ncbi.nlm.nih.gov/nuccore/*').
     """
     input:
-        metadata = "data/metadata_geo_improvements.tsv",
+        metadata = "data/{species}/metadata_geo-improvements.tsv",
     output:
-        metadata = temp("data/all_metadata_added.tsv")
+        metadata = "data/{species}/metadata_acessions.tsv",
     params:
         pathoplexus_accession=config['curate']['pathoplexus_accession'],
         pathoplexus_accession_url=config['curate']['pathoplexus_accession'] + "__url",
         insdc_accession=config['curate']['insdc_accession'],
         insdc_accession_url=config['curate']['insdc_accession'] + "__url",
     benchmark:
-        "benchmarks/add_accession_urls.txt"
+        "benchmarks/{species}/add_accession_urls.txt"
     log:
-        "logs/add_accession_urls.txt"
+        "logs/{species}/add_accession_urls.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -297,17 +272,67 @@ rule add_accession_urls:
         > {output.metadata:q}
         """
 
+
+rule add_nextclade_clades:
+    """
+    Normally we use nextclade for a varity of metadata fields, but here we only add
+    the 'clade' column, renaming it to 'outbreak'.
+    This is only applicable for Zaire Ebolavirus at the moment
+    """
+    input:
+        metadata="data/{species}/metadata_acessions.tsv",
+        nextclade="data/{species}/nextclade.tsv",
+    output:
+        nextclade_subset=temp("data/{species}/nextclade_clade-only.tsv"),
+        metadata="data/{species}/metadata_outbreak-clade.tsv",
+    benchmark:
+        "benchmarks/{species}/add_nextclade_clades.txt"
+    log:
+        "logs/{species}/add_nextclade_clades.txt"
+    wildcard_constraints:
+        species='ebov'
+    shell:
+        r"""
+        exec &> >(tee {log:q})
+
+        cat {input.nextclade} \
+            | csvtk -t cut -f seqName,clade \
+            | csvtk -t rename -f seqName,clade -n accession,outbreak \
+            > {output.nextclade_subset:q}
+
+        augur merge \
+            --metadata metadata={input.metadata:q} nextclade={output.nextclade_subset:q} \
+            --metadata-id-columns accession \
+            --output-metadata {output.metadata:q} \
+            --no-source-columns
+        """
+
+
+def metadata_all_fields(wildcards):
+    # Zaire has Nextclade outbreak (clade) annotation
+    if wildcards.species == 'ebov':
+        return "data/ebov/metadata_outbreak-clade.tsv"
+    return f"data/{wildcards.species}/metadata_acessions.tsv"
+
+def metadata_fields(wildcards):
+    config_values = config["curate"]["metadata_columns"]
+    if not wildcards.species == 'ebov':
+        config_values = [x for x in config_values if x!='outbreak']
+    return ",".join(config_values)
+
+    
+
 rule subset_metadata:
     input:
-        metadata="data/all_metadata_added.tsv",
+        metadata=metadata_all_fields,
     output:
-        subset_metadata="data/subset_metadata.tsv",
+        subset_metadata="results/{species}/metadata.tsv",
     params:
-        metadata_fields=",".join(config["curate"]["metadata_columns"]),
+        metadata_fields=metadata_fields,
     benchmark:
-        "benchmarks/subset_metadata.txt"
+        "benchmarks/{species}/subset_metadata.txt"
     log:
-        "logs/subset_metadata.txt"
+        "logs/{species}/subset_metadata.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -316,20 +341,18 @@ rule subset_metadata:
             {input.metadata:q} > {output.subset_metadata:q}
         """
 
-rule extract_open_data:
-    # NOTE: the nextclade translations are not yet subset to open data only
+rule extract_open_seqs_metadata:
+    # NOTE: we don't yet extract open data for the nextclade translations!
     input:
-        metadata = "results/metadata.tsv",
-        sequences = "results/sequences.fasta",
-        alignment = "results/alignment.fasta",
+        metadata = "results/{species}/metadata.tsv",
+        sequences = "results/{species}/sequences.fasta",
     output:
-        metadata = "results/metadata_open.tsv",
-        sequences = "results/sequences_open.fasta",
-        alignment = "results/alignment_open.fasta",
+        metadata = "results/{species}/metadata_open.tsv",
+        sequences = "results/{species}/sequences_open.fasta",
     benchmark:
-        "benchmarks/extract_open_data.txt"
+        "benchmarks/{species}/extract_open_seqs_metadata.txt"
     log:
-        "logs/extract_open_data.txt"
+        "logs/{species}/extract_open_seqs_metadata.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -341,6 +364,25 @@ rule extract_open_data:
             --exclude-where "dataUseTerms=RESTRICTED" \
             --output-metadata {output.metadata:q} \
             --output-sequences {output.sequences:q}
+        """
+
+rule extract_open_alignment:
+    # alignments are only produced for species with a nextclade dataset
+    # which currently is only EBOV 
+    input:
+        metadata = "results/{species}/metadata.tsv",
+        alignment = "results/{species}/alignment.fasta",
+    output:
+        alignment = "results/{species}/alignment_open.fasta",
+    benchmark:
+        "benchmarks/{species}/extract_open_alignment.txt"
+    log:
+        "logs/{species}/extract_open_alignment.txt"
+    wildcard_constraints:
+            species='ebov'
+    shell:
+        r"""
+        exec &> >(tee {log:q})
 
         augur filter \
             --metadata {input.metadata:q} \

--- a/ingest/rules/fetch.smk
+++ b/ingest/rules/fetch.smk
@@ -1,15 +1,5 @@
 """
 This part of the workflow handles fetching sequences and metadata from Pathoplexus.
-
-REQUIRED INPUTS:
-
-    None
-
-OUTPUTS:
-
-    data/sequences.ndjson
-    data/ncbi_entrez.ndjson
-
 """
 
 ###########################################################################
@@ -18,15 +8,15 @@ OUTPUTS:
 
 rule download_ppx_seqs:
     output:
-        sequences= "data/ppx_sequences.fasta",
+        sequences= "data/{species}/ppx_sequences.fasta",
     params:
-        sequences_url=config["ppx_fetch"]["seqs"],
+        sequences_url=lambda w: config["ppx_fetch"][w.species]["seqs"],
     # Allow retries in case of network errors
     retries: 5
     benchmark:
-        "benchmarks/download_ppx_seqs.txt"
+        "benchmarks/{species}/download_ppx_seqs.txt"
     log:
-        "logs/download_ppx_seqs.txt"
+        "logs/{species}/download_ppx_seqs.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -36,16 +26,16 @@ rule download_ppx_seqs:
 
 rule download_ppx_meta:
     output:
-        metadata= "data/ppx_metadata.csv"
+        metadata= "data/{species}/ppx_metadata.csv"
     params:
-        metadata_url=config["ppx_fetch"]["meta"],
+        metadata_url=lambda w: config["ppx_fetch"][w.species]["meta"],
         fields = ",".join(config["ppx_metadata_fields"])
     # Allow retries in case of network errors
     retries: 5
     benchmark:
-        "benchmarks/download_ppx_meta.txt"
+        "benchmarks/{species}/download_ppx_meta.txt"
     log:
-        "logs/download_ppx_meta.txt"
+        "logs/{species}/download_ppx_meta.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -55,14 +45,14 @@ rule download_ppx_meta:
 
 rule format_ppx_ndjson:
     input:
-        sequences="data/ppx_sequences.fasta",
-        metadata="data/ppx_metadata.csv"
+        sequences="data/{species}/ppx_sequences.fasta",
+        metadata="data/{species}/ppx_metadata.csv"
     output:
-        ndjson="data/sequences.ndjson"
+        ndjson="data/{species}/sequences.ndjson"
     benchmark:
-        "benchmarks/format_ppx_ndjson.txt"
+        "benchmarks/{species}/format_ppx_ndjson.txt"
     log:
-        "logs/format_ppx_ndjson.txt"
+        "logs/{species}/format_ppx_ndjson.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -78,7 +68,7 @@ rule format_ppx_ndjson:
         """
 
 ###########################################################################
-########################## 2. Fetch from Entrez ###########################
+########### 2. Fetch from Entrez (Zaire Ebolavirus only) ##################
 ###########################################################################
 
 
@@ -86,13 +76,13 @@ rule fetch_from_ncbi_entrez:
     params:
         term=config["entrez_search_term"],
     output:
-        genbank="data/genbank.gb",
+        genbank="data/ebov/genbank.gb", # zaire ebolavirus only
     # Allow retries in case of network errors
     retries: 5
     benchmark:
-        "benchmarks/fetch_from_ncbi_entrez.txt"
+        "benchmarks/ebov/fetch_from_ncbi_entrez.txt"
     log:
-        "logs/fetch_from_ncbi_entrez.txt",
+        "logs/ebov/fetch_from_ncbi_entrez.txt",
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -105,13 +95,13 @@ rule fetch_from_ncbi_entrez:
 
 rule parse_genbank_to_ndjson:
     input:
-        genbank="data/genbank.gb",
+        genbank="data/ebov/genbank.gb",
     output:
-        ndjson="data/ncbi_entrez.ndjson",
+        ndjson="data/ebov/ncbi_entrez.ndjson",
     benchmark:
-        "benchmarks/parse_genbank_to_ndjson.txt"
+        "benchmarks/ebov/parse_genbank_to_ndjson.txt"
     log:
-        "logs/parse_genbank_to_ndjson.txt"
+        "logs/ebov/parse_genbank_to_ndjson.txt"
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -130,11 +120,11 @@ rule parse_genbank_to_ndjson:
         """
 
 ###########################################################################
-########################## 3. Fetch from INRB #############################
+############# 3. Fetch from INRB (Zaire Ebolavirus only) ##################
 ###########################################################################
 
 rule fetch_inrb_nord_kivu_metadata:
-    output: "data/inrb-drc-nord-kivu-metadata.tsv"
+    output: "data/ebov/inrb-drc-nord-kivu-metadata.tsv"
     shell:
         r"""
         curl -fsSL https://github.com/inrb-drc/ebola-nord-kivu/raw/ba9b9b48ba1e8db83486d653f3043d9671611594/data/metadata.tsv -o {output:q}

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -3,11 +3,13 @@
 rule get_nextclade_dataset:
     """Download Nextclade dataset"""
     output:
-        dataset=f"data/ebola-zaire.zip",
+        dataset="data/{species}/nextclade-dataset.zip",
     benchmark:
-        "benchmarks/get_nextclade_dataset.txt"
+        "benchmarks/{species}/get_nextclade_dataset.txt"
     log:
-        "logs/get_nextclade_dataset.txt"
+        "logs/{species}/get_nextclade_dataset.txt"
+    wildcard_constraints:
+        species='ebov'
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -19,20 +21,23 @@ rule get_nextclade_dataset:
 
 rule run_nextclade:
     input:
-        sequences="results/sequences.fasta",
-        dataset="data/ebola-zaire.zip",
+        sequences="results/{species}/sequences.fasta",
+        dataset="data/{species}/nextclade-dataset.zip",
     output:
-        metadata="data/nextclade.tsv",
-        alignment="results/alignment.fasta",
-        translations="results/translations.zip",
+        metadata="data/{species}/nextclade.tsv",
+        alignment="results/{species}/alignment.fasta",
+        translations="results/{species}/translations.zip",
     params:
         # The lambda is used to deactivate automatic wildcard expansion.
         # https://github.com/snakemake/snakemake/blob/384d0066c512b0429719085f2cf886fdb97fd80a/snakemake/rules.py#L997-L1000
-        translations=lambda w: "results/translations/{cds}.fasta",
+        translations=lambda w: f"results/{w.species}/translations/{{cds}}.fasta",
+        translations_dir = "results/{species}/translations/"
     benchmark:
-        "benchmarks/run_nextclade.txt"
+        "benchmarks/{species}/run_nextclade.txt"
     log:
-        "logs/run_nextclade.txt"
+        "logs/{species}/run_nextclade.txt"
+    wildcard_constraints:
+        species='ebov'
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -44,5 +49,5 @@ rule run_nextclade:
             --output-fasta {output.alignment:q} \
             --output-translations {params.translations:q}
 
-        zip -rj {output.translations:q} results/translations
+        zip -rj {output.translations:q} {params.translations_dir:q}
         """

--- a/ingest/scripts/lab_hosts.py
+++ b/ingest/scripts/lab_hosts.py
@@ -115,10 +115,10 @@ def is_lab_host(row):
     """
     if row['is_lab_host'] is True:
         return True
-    if row['title'] in LAB_TITLES:
+    if row.get('title', '') in LAB_TITLES:
         excluded['title'][row['title']].append(row)
         return True
-    if row['note'] in NOTES:
+    if row.get('note', '') in NOTES:
         excluded['note'][row['note']].append(row)
         return True
     return ''

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -30,8 +30,8 @@ rule filter:
       - excluding strains in {input.exclude}
     """
     input:
-        sequences = "../../ingest/results/sequences.fasta",
-        metadata = "../../ingest/results/metadata.tsv",
+        sequences = "../../ingest/ebov/results/sequences.fasta",
+        metadata = "../../ingest/ebov/results/metadata.tsv",
         exclude = lambda w: config["build_params"][w.build]["filter"]["exclude"],
         include = lambda w: config["build_params"][w.build]["filter"]["include"],
     output:


### PR DESCRIPTION
Moves the ingest structure to handle multiple species currently supported on PPX.

The previous snakefile's logic was broken - with a hardcoded `include: "rules/nextclade.smk"` followed by a conditional one, so I've removed that to simplify the logic.

There's species-specific behaviour in the workflow:
1. We only currently download a nextclade dataset for (Zaire) EBOV
2. (Zaire) EBOV merges in multiple non-PPX sources whereas BDBV & SUDV just use PPX data
