### PR TITLE
Collapse short branches in the species trees

### DIFF
--- a/phylogenetic/species-workflows/generic.snakefile
+++ b/phylogenetic/species-workflows/generic.snakefile
@@ -85,7 +85,9 @@ rule tree:
     shell:
         """
         augur tree \
+            --method iqtree \
             --alignment {input.aligned} \
+            --tree-builder-args="--polytomy" \
             --output {output.tree}
         """
 


### PR DESCRIPTION
## Description of proposed changes

I noticed the BDBV tree "leans" a bit because of a few short branches. `augur refine` was set to `--keep-polytomies` but `augur tree`  was calling iqtree without the `--polytomies` flag. This adds that flag and makes the call to iqtree explicit. It will have similar effects on other species trees. 

### Before 
<img width="1257" height="769" alt="image" src="https://github.com/user-attachments/assets/95fcb6ea-98f9-4f5b-8d43-12eaa16955ef" />

### After 

<img width="1255" height="742" alt="image" src="https://github.com/user-attachments/assets/c9ce8fc1-86af-4fe7-aa43-8738f91f5470" />


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
