### PR TITLE
[phylo automation] run only builds for species with new data

### DIFF
--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -66,43 +66,101 @@ jobs:
     needs: [ingest]
     runs-on: ubuntu-latest
     outputs:
-      cache-hit: ${{ steps.check-cache.outputs.cache-hit }}
+      # JSON list of builds to run, e.g. ["ebov/all-outbreaks","sudv/all-outbreaks"].
+      # Empty ("[]") means no Ebola species have new data and thus all phylogenetic builds are skipped.
+      builds: ${{ steps.determine-builds.outputs.builds }}
     steps:
-      - name: Get sha256sum
+      - name: Get sha256sum per species
         id: get-sha256sum
         env:
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
         run: |
-          s3_urls=(
-            "s3://nextstrain-data/files/workflows/ebola/ebov/metadata.tsv.zst"
-          )
-
           # Code below is modified from ingest/upload-to-s3
           # https://github.com/nextstrain/ingest/blob/c0b4c6bb5e6ccbba86374d2c09b42077768aac23/upload-to-s3#L23-L29
 
           no_hash=0000000000000000000000000000000000000000000000000000000000000000
 
-          for s3_url in "${s3_urls[@]}"; do
-            s3path="${s3_url#s3://}"
-            bucket="${s3path%%/*}"
-            key="${s3path#*/}"
-
-            s3_hash="$(aws s3api head-object --no-sign-request --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
-            echo "${s3_hash}" | tee -a ingest-output-sha256sum
+          # Each species has both open and restricted metadata; concatenate the
+          # hashes of both into the species' file so that a change to *either*
+          # results in a new cache key (and thus triggers that species' builds).
+          for species in bdbv sudv ebov; do
+            : > "ingest-output-sha256sum-${species}"
+            for access in open restricted; do
+              key="files/workflows/ebola/${species}/metadata_${access}.tsv.zst"
+              s3_hash="$(aws s3api head-object --no-sign-request --bucket nextstrain-data --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
+              echo "${s3_hash}" | tee -a "ingest-output-sha256sum-${species}"
+            done
           done
 
-      - name: Check cache
-        id: check-cache
+      # The shasum for each species is stored using GitHub Actions cache, with the shasum
+      # in the filename; see <https://github.com/nextstrain/ebola/actions/caches>
+      # A cache miss (cache-hit != 'true') means the species' metadata hash is new since
+      # the last run, so its builds should run. A cache miss also results in a new cache
+      # file generated so that a subsequent run with the same hash is a hit (and is
+      # therefore skipped); this cache save is automatic by 'actions/cache'.
+      - name: Check cache (bdbv)
+        id: cache-bdbv
         uses: actions/cache@v6
         with:
-          path: ingest-output-sha256sum
-          key: ingest-output-sha256sum-${{ hashFiles('ingest-output-sha256sum') }}
+          path: ingest-output-sha256sum-bdbv
+          key: ingest-output-sha256sum-bdbv-${{ hashFiles('ingest-output-sha256sum-bdbv') }}
           lookup-only: true
+
+      - name: Check cache (sudv)
+        id: cache-sudv
+        uses: actions/cache@v6
+        with:
+          path: ingest-output-sha256sum-sudv
+          key: ingest-output-sha256sum-sudv-${{ hashFiles('ingest-output-sha256sum-sudv') }}
+          lookup-only: true
+
+      - name: Check cache (ebov)
+        id: cache-ebov
+        uses: actions/cache@v6
+        with:
+          path: ingest-output-sha256sum-ebov
+          key: ingest-output-sha256sum-ebov-${{ hashFiles('ingest-output-sha256sum-ebov') }}
+          lookup-only: true
+
+      # Map the updated species onto the phylogenetic builds that should run and emit
+      # them as a JSON list for the phylogenetic job's `--config builds=[...]`.
+      # NOTE: this species -> builds mapping must be kept in sync with the `builds`
+      # in phylogenetic/build-configs/nextstrain-automation/config.yaml
+      - name: Determine builds
+        id: determine-builds
+        env:
+          IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          BDBV_HIT: ${{ steps.cache-bdbv.outputs.cache-hit }}
+          SUDV_HIT: ${{ steps.cache-sudv.outputs.cache-hit }}
+          EBOV_HIT: ${{ steps.cache-ebov.outputs.cache-hit }}
+        run: |
+          builds=()
+
+          # A workflow_dispatch forces every build to run; otherwise only run the
+          # builds for species whose metadata hash changed (i.e. a cache miss).
+          if [[ "$IS_DISPATCH" == "true" || "$BDBV_HIT" != "true" ]]; then
+            builds+=(bdbv/all-outbreaks bdbv/drc-uganda-2026)
+          fi
+          if [[ "$IS_DISPATCH" == "true" || "$SUDV_HIT" != "true" ]]; then
+            builds+=(sudv/all-outbreaks)
+          fi
+          if [[ "$IS_DISPATCH" == "true" || "$EBOV_HIT" != "true" ]]; then
+            builds+=(ebov/all-outbreaks)
+          fi
+
+          if [[ ${#builds[@]} -eq 0 ]]; then
+            builds_json='[]'
+          else
+            builds_json="$(printf '%s\n' "${builds[@]}" | jq -R . | jq -sc .)"
+          fi
+
+          echo "Builds to run: ${builds_json}"
+          echo "builds=${builds_json}" >> "$GITHUB_OUTPUT"
 
 
   phylogenetic:
     needs: [check-new-data]
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-new-data.outputs.cache-hit != 'true' }}
+    if: ${{ needs.check-new-data.outputs.builds != '[]' }}
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
@@ -114,7 +172,8 @@ jobs:
       run: |
         nextstrain build phylogenetic \
           deploy_all \
-          --configfile build-configs/nextstrain-automation/config.yaml
+          --configfile build-configs/nextstrain-automation/config.yaml \
+          --config 'builds=${{ needs.check-new-data.outputs.builds }}'
       artifact-name: phylo-all-outbreaks-output
       artifact-paths: |
         phylogenetic/benchmarks/

--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -70,6 +70,11 @@ jobs:
       # Empty ("[]") means no Ebola species have new data and thus all phylogenetic builds are skipped.
       builds: ${{ steps.determine-builds.outputs.builds }}
     steps:
+      # Needed so `determine-builds` can read the `builds` list out of the
+      # phylogenetic automation config rather than hardcoding it here.
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Get sha256sum per species
         id: get-sha256sum
         env:
@@ -122,30 +127,41 @@ jobs:
           key: ingest-output-sha256sum-ebov-${{ hashFiles('ingest-output-sha256sum-ebov') }}
           lookup-only: true
 
-      # Map the updated species onto the phylogenetic builds that should run and emit
-      # them as a JSON list for the phylogenetic job's `--config builds=[...]`.
-      # NOTE: this species -> builds mapping must be kept in sync with the `builds`
-      # in phylogenetic/build-configs/nextstrain-automation/config.yaml
+      # Emit the builds to run as a JSON list for the phylogenetic job's
+      # `--config builds=[...]`. Rather than hardcode a species -> builds mapping,
+      # read the `builds` list from the automation config (the single source of
+      # truth for which builds exist) and keep those belonging to a changed
+      # species. New builds added to the config are picked up automatically.
       - name: Determine builds
         id: determine-builds
         env:
+          CONFIG: phylogenetic/build-configs/nextstrain-automation/config.yaml
           IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
           BDBV_HIT: ${{ steps.cache-bdbv.outputs.cache-hit }}
           SUDV_HIT: ${{ steps.cache-sudv.outputs.cache-hit }}
           EBOV_HIT: ${{ steps.cache-ebov.outputs.cache-hit }}
         run: |
-          builds=()
+          # Species with new data (cache miss); a workflow_dispatch forces all of them.
+          changed_species=()
+          if [[ "$IS_DISPATCH" == "true" || "$BDBV_HIT" != "true" ]]; then changed_species+=(bdbv); fi
+          if [[ "$IS_DISPATCH" == "true" || "$SUDV_HIT" != "true" ]]; then changed_species+=(sudv); fi
+          if [[ "$IS_DISPATCH" == "true" || "$EBOV_HIT" != "true" ]]; then changed_species+=(ebov); fi
 
-          # A workflow_dispatch forces every build to run; otherwise only run the
-          # builds for species whose metadata hash changed (i.e. a cache miss).
-          if [[ "$IS_DISPATCH" == "true" || "$BDBV_HIT" != "true" ]]; then
-            builds+=(bdbv/all-outbreaks bdbv/drc-uganda-2026)
-          fi
-          if [[ "$IS_DISPATCH" == "true" || "$SUDV_HIT" != "true" ]]; then
-            builds+=(sudv/all-outbreaks)
-          fi
-          if [[ "$IS_DISPATCH" == "true" || "$EBOV_HIT" != "true" ]]; then
-            builds+=(ebov/all-outbreaks)
+          # Keep the configured builds (e.g. "bdbv/all-outbreaks") whose species
+          # prefix is among the changed species. yq is preinstalled on the
+          # GitHub-hosted ubuntu runners.
+          builds=()
+          if [[ ${#changed_species[@]} -gt 0 ]]; then
+            mapfile -t all_builds < <(yq '.builds[]' "$CONFIG")
+            for build in "${all_builds[@]}"; do
+              species="${build%%/*}"
+              for changed in "${changed_species[@]}"; do
+                if [[ "$species" == "$changed" ]]; then
+                  builds+=("$build")
+                  break
+                fi
+              done
+            done
           fi
 
           if [[ ${#builds[@]} -eq 0 ]]; then

--- a/phylogenetic/build-configs/nextstrain-automation/config.yaml
+++ b/phylogenetic/build-configs/nextstrain-automation/config.yaml
@@ -1,7 +1,10 @@
 # This configuration file should contain all required configuration parameters
 # for the ingest workflow to run with additional Nextstrain automation rules.
 
-# Only a subset of builds are run via our automation
+# Only a subset of builds are intended to be run via our automation
+# NOTE: `ingest-to-phylogenetic.yaml` overrides this via --config, but we keep
+# this copy here for (a) clarity and (b) in case we manually want to run the
+# `deploy_all` rule
 builds:
    - bdbv/all-outbreaks
    - bdbv/drc-uganda-2026


### PR DESCRIPTION
Previously the check-new-data job only checked the ebov metadata for updates and, on any change, triggered a phylogenetic run of all builds. Now that bdbv, sudv and ebov are all uploaded by ingest, check each species independently and run only the builds for species whose data actually changed. A workflow_dispatch still forces every build to run.

Relatedly, for each species there's now two metadata files _open and _restricted, so we get the hash for each and join them together.

Closes #71

@joverlee521 @victorlin would you mind taking a quick look? I don't think we've used this exact approach elsewhere